### PR TITLE
Fix booking overlap query missing same-start and same-end edge cases

### DIFF
--- a/booking-system-app/src/main/java/com/acs/bookingsystem/booking/repository/BookingRepository.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/booking/repository/BookingRepository.java
@@ -19,12 +19,7 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
           + "WHERE b.room = :room "
           + "AND (:shareable IS NULL OR b.shareable = :shareable) "
           + "AND (SELECT bs.status FROM BookingStatus bs WHERE bs.booking = b ORDER BY bs.createdOn DESC LIMIT 1) = 'BOOKED' "
-          + "AND ("
-          + "     (:dateFrom > b.bookedFrom AND :dateTo < b.bookedTo) OR "
-          + "     (b.bookedFrom >= :dateFrom AND b.bookedTo <= :dateTo) OR "
-          + "     (b.bookedFrom > :dateFrom AND b.bookedFrom < :dateTo AND :dateTo < b.bookedTo) OR "
-          + "     (b.bookedTo > :dateFrom AND b.bookedFrom < :dateFrom AND b.bookedTo < :dateTo)"
-          + ") "
+          + "AND (b.bookedFrom < :dateTo AND b.bookedTo > :dateFrom) "
           + "ORDER BY b.bookedFrom ASC")
   List<Booking> findActiveBookingsForRoomAndTimeRange(
       @Param("room") Room room,

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/validation/NonShareableConflictValidatorTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/validation/NonShareableConflictValidatorTest.java
@@ -41,7 +41,7 @@ class NonShareableConflictValidatorTest {
             eq(Room.ASTAIRE), eq(false), any(), any()))
         .thenReturn(List.of());
 
-    Optional<ValidationFailure> result = validator.validate(request());
+    Optional<ValidationFailure> result = validator.validate(nonShareableRequest());
     assertThat(result).isEmpty();
   }
 
@@ -51,13 +51,29 @@ class NonShareableConflictValidatorTest {
             eq(Room.ASTAIRE), eq(false), any(), any()))
         .thenReturn(List.of(new Booking()));
 
-    Optional<ValidationFailure> result = validator.validate(request());
+    Optional<ValidationFailure> result = validator.validate(nonShareableRequest());
     assertThat(result).isPresent();
     assertThat(result.get().code()).isEqualTo(ErrorCode.BOOKING_CONFLICT);
     assertThat(result.get().message()).contains("unavailable");
   }
 
-  private BookingRequest request() {
+  @Test
+  void givenShareableRequestWithExistingNonShareableBooking_shouldFail() {
+    when(bookingRepository.findActiveBookingsForRoomAndTimeRange(
+            eq(Room.ASTAIRE), eq(false), any(), any()))
+        .thenReturn(List.of(new Booking()));
+
+    Optional<ValidationFailure> result = validator.validate(shareableRequest());
+    assertThat(result).isPresent();
+    assertThat(result.get().code()).isEqualTo(ErrorCode.BOOKING_CONFLICT);
+    assertThat(result.get().message()).contains("unavailable");
+  }
+
+  private BookingRequest nonShareableRequest() {
     return new BookingRequest(Room.ASTAIRE, ClassType.PRIVATE, false, START, END);
+  }
+
+  private BookingRequest shareableRequest() {
+    return new BookingRequest(Room.ASTAIRE, ClassType.PRACTICE, true, START, END);
   }
 }

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/validation/ShareabilityLimitValidatorTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/validation/ShareabilityLimitValidatorTest.java
@@ -85,6 +85,39 @@ class ShareabilityLimitValidatorTest {
     assertThat(result.get().message()).contains("3");
   }
 
+  @Test
+  void givenShareableRequestWithStaggeredBookingsConvergingAtLimit_shouldFail() {
+    // A:[10:00-10:20], B:[10:10-10:30], C:[10:15-10:35] — all three active at slot [10:15-10:20]
+    List<Booking> staggered =
+        List.of(
+            shareableBooking(START, START.plusMinutes(20)),
+            shareableBooking(START.plusMinutes(10), START.plusMinutes(30)),
+            shareableBooking(START.plusMinutes(15), START.plusMinutes(35)));
+    when(bookingRepository.findActiveBookingsForRoomAndTimeRange(
+            eq(Room.ASTAIRE), eq(true), any(), any()))
+        .thenReturn(staggered);
+
+    Optional<ValidationFailure> result = validator.validate(shareableRequest());
+    assertThat(result).isPresent();
+    assertThat(result.get().code()).isEqualTo(ErrorCode.BOOKING_SHAREABLE_LIMIT);
+  }
+
+  @Test
+  void givenShareableRequestWithStaggeredBookingsNeverConverging_shouldPass() {
+    // A:[10:00-10:20], B:[10:25-10:45], C:[10:50-11:10] — never more than 1 active per slot
+    List<Booking> staggered =
+        List.of(
+            shareableBooking(START, START.plusMinutes(20)),
+            shareableBooking(START.plusMinutes(25), START.plusMinutes(45)),
+            shareableBooking(START.plusMinutes(50), END.plusMinutes(10)));
+    when(bookingRepository.findActiveBookingsForRoomAndTimeRange(
+            eq(Room.ASTAIRE), eq(true), any(), any()))
+        .thenReturn(staggered);
+
+    Optional<ValidationFailure> result = validator.validate(shareableRequest());
+    assertThat(result).isEmpty();
+  }
+
   private BookingRequest shareableRequest() {
     return new BookingRequest(Room.ASTAIRE, ClassType.PRACTICE, true, START, END);
   }

--- a/booking-system-it/src/test/java/com/acs/bookingsystem/booking/repository/BookingRepositoryIT.java
+++ b/booking-system-it/src/test/java/com/acs/bookingsystem/booking/repository/BookingRepositoryIT.java
@@ -66,6 +66,105 @@ class BookingRepositoryIT extends BaseIntegrationTest {
   }
 
   @Test
+  void findActiveBookingsForRoomAndTimeRange_detectsOverlap_whenExistingContainsNew() {
+    Booking booking =
+        saveBookingWithStatus(
+            Room.ASTAIRE, false, FROM.minusHours(1), TO.plusHours(1), BookingStatusType.BOOKED);
+
+    List<Booking> result =
+        bookingRepository.findActiveBookingsForRoomAndTimeRange(Room.ASTAIRE, null, FROM, TO);
+
+    assertThat(result).extracting(Booking::getUid).contains(booking.getUid());
+  }
+
+  @Test
+  void findActiveBookingsForRoomAndTimeRange_detectsOverlap_whenNewContainsExisting() {
+    Booking booking =
+        saveBookingWithStatus(
+            Room.ASTAIRE,
+            false,
+            FROM.plusMinutes(30),
+            TO.minusMinutes(15),
+            BookingStatusType.BOOKED);
+
+    List<Booking> result =
+        bookingRepository.findActiveBookingsForRoomAndTimeRange(Room.ASTAIRE, null, FROM, TO);
+
+    assertThat(result).extracting(Booking::getUid).contains(booking.getUid());
+  }
+
+  @Test
+  void findActiveBookingsForRoomAndTimeRange_detectsOverlap_whenExistingStartsDuringNew() {
+    Booking booking =
+        saveBookingWithStatus(
+            Room.ASTAIRE, false, FROM.plusMinutes(30), TO.plusHours(1), BookingStatusType.BOOKED);
+
+    List<Booking> result =
+        bookingRepository.findActiveBookingsForRoomAndTimeRange(Room.ASTAIRE, null, FROM, TO);
+
+    assertThat(result).extracting(Booking::getUid).contains(booking.getUid());
+  }
+
+  @Test
+  void findActiveBookingsForRoomAndTimeRange_detectsOverlap_whenExistingEndsDuringNew() {
+    Booking booking =
+        saveBookingWithStatus(
+            Room.ASTAIRE,
+            false,
+            FROM.minusHours(1),
+            FROM.plusMinutes(30),
+            BookingStatusType.BOOKED);
+
+    List<Booking> result =
+        bookingRepository.findActiveBookingsForRoomAndTimeRange(Room.ASTAIRE, null, FROM, TO);
+
+    assertThat(result).extracting(Booking::getUid).contains(booking.getUid());
+  }
+
+  @Test
+  void findActiveBookingsForRoomAndTimeRange_detectsOverlap_whenExistingHasSameStart() {
+    Booking booking =
+        saveBookingWithStatus(Room.ASTAIRE, false, FROM, TO.plusHours(1), BookingStatusType.BOOKED);
+
+    List<Booking> result =
+        bookingRepository.findActiveBookingsForRoomAndTimeRange(Room.ASTAIRE, null, FROM, TO);
+
+    assertThat(result).extracting(Booking::getUid).contains(booking.getUid());
+  }
+
+  @Test
+  void findActiveBookingsForRoomAndTimeRange_detectsOverlap_whenExistingHasSameEnd() {
+    Booking booking =
+        saveBookingWithStatus(
+            Room.ASTAIRE, false, FROM.minusHours(1), TO, BookingStatusType.BOOKED);
+
+    List<Booking> result =
+        bookingRepository.findActiveBookingsForRoomAndTimeRange(Room.ASTAIRE, null, FROM, TO);
+
+    assertThat(result).extracting(Booking::getUid).contains(booking.getUid());
+  }
+
+  @Test
+  void findActiveBookingsForRoomAndTimeRange_excludesAdjacentBookingEndingAtRangeStart() {
+    saveBookingWithStatus(Room.ASTAIRE, false, FROM.minusHours(2), FROM, BookingStatusType.BOOKED);
+
+    List<Booking> result =
+        bookingRepository.findActiveBookingsForRoomAndTimeRange(Room.ASTAIRE, null, FROM, TO);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void findActiveBookingsForRoomAndTimeRange_excludesAdjacentBookingStartingAtRangeEnd() {
+    saveBookingWithStatus(Room.ASTAIRE, false, TO, TO.plusHours(1), BookingStatusType.BOOKED);
+
+    List<Booking> result =
+        bookingRepository.findActiveBookingsForRoomAndTimeRange(Room.ASTAIRE, null, FROM, TO);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
   void findActiveBookingsForRoomAndTimeRange_excludesCancelledBookings() {
     saveBookingWithStatus(Room.ASTAIRE, false, FROM, TO, BookingStatusType.CANCELLED);
 


### PR DESCRIPTION
Replaced the 4-condition OR clause with the canonical half-open interval check (b.bookedFrom < :dateTo AND b.bookedTo > :dateFrom), which correctly detects all overlap shapes including when two bookings share a start or end time. Added full integration test coverage for all overlap geometries and extended validator unit tests with staggered booking scenarios.