### PR TITLE
Fix user deactivation to only cancel upcoming bookings, migrate to Of…

### DIFF
--- a/booking-system-app/src/main/java/com/acs/bookingsystem/BookingSystemApplication.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/BookingSystemApplication.java
@@ -1,5 +1,6 @@
 package com.acs.bookingsystem;
 
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class BookingSystemApplication {
 
   public static void main(String[] args) {
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     SpringApplication.run(BookingSystemApplication.class, args);
   }
 }

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/booking/controller/BookingController.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/booking/controller/BookingController.java
@@ -20,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@SuppressWarnings("java:S4684") // @CurrentUser resolves from security context, not request body
 @RestController
 @AllArgsConstructor
 @RequestMapping("/api/v1/bookings")

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/booking/controller/BookingController.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/booking/controller/BookingController.java
@@ -10,7 +10,7 @@ import com.acs.bookingsystem.booking.view.dto.BookingView;
 import com.acs.bookingsystem.security.CurrentUser;
 import com.acs.bookingsystem.user.entity.User;
 import jakarta.validation.Valid;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -60,8 +60,8 @@ public class BookingController {
   public ResponseEntity<List<BookingView>> getBookingSchedule(
       @CurrentUser User user,
       @RequestParam Room room,
-      @RequestParam LocalDateTime dateFrom,
-      @RequestParam LocalDateTime dateTo) {
+      @RequestParam OffsetDateTime dateFrom,
+      @RequestParam OffsetDateTime dateTo) {
     List<BookingView> bookings =
         bookingService.getBookingsByRoomAndDates(room, dateFrom, dateTo).stream()
             .map(b -> viewFactory.createView(b, user.getRole()))

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/booking/entity/Booking.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/booking/entity/Booking.java
@@ -5,7 +5,7 @@ import com.acs.bookingsystem.danceclass.entity.DanceClass;
 import com.acs.bookingsystem.user.entity.User;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.*;
 
@@ -39,10 +39,10 @@ public class Booking {
   private boolean shareable;
 
   @Column(nullable = false)
-  private LocalDateTime bookedFrom;
+  private OffsetDateTime bookedFrom;
 
   @Column(nullable = false)
-  private LocalDateTime bookedTo;
+  private OffsetDateTime bookedTo;
 
   @Column(nullable = false)
   private BigDecimal totalPrice;

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/booking/entity/BookingStatus.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/booking/entity/BookingStatus.java
@@ -3,8 +3,7 @@ package com.acs.bookingsystem.booking.entity;
 import com.acs.bookingsystem.booking.enums.BookingStatusType;
 import com.acs.bookingsystem.user.entity.User;
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,7 +30,7 @@ public class BookingStatus {
   private BookingStatusType status;
 
   @Column(nullable = false)
-  private LocalDateTime createdOn;
+  private Instant createdOn;
 
   @ManyToOne
   @JoinColumn(referencedColumnName = "id", nullable = false)
@@ -40,7 +39,7 @@ public class BookingStatus {
   @PrePersist
   void prePersist() {
     if (createdOn == null) {
-      createdOn = LocalDateTime.now(ZoneId.systemDefault());
+      createdOn = Instant.now();
     }
   }
 }

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/booking/enums/BookingStatusType.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/booking/enums/BookingStatusType.java
@@ -5,5 +5,6 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum BookingStatusType {
   BOOKED,
-  CANCELLED
+  CANCELLED,
+  COMPLETED
 }

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/booking/repository/BookingRepository.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/booking/repository/BookingRepository.java
@@ -2,7 +2,7 @@ package com.acs.bookingsystem.booking.repository;
 
 import com.acs.bookingsystem.booking.entity.Booking;
 import com.acs.bookingsystem.booking.enums.Room;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -24,8 +24,8 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
   List<Booking> findActiveBookingsForRoomAndTimeRange(
       @Param("room") Room room,
       @Param("shareable") Boolean shareable,
-      @Param("dateFrom") LocalDateTime dateFrom,
-      @Param("dateTo") LocalDateTime dateTo);
+      @Param("dateFrom") OffsetDateTime dateFrom,
+      @Param("dateTo") OffsetDateTime dateTo);
 
   Page<Booking> findAllByUserId(Long userId, Pageable pageable);
 
@@ -39,6 +39,7 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
   @Query(
       "SELECT b FROM Booking b "
           + "WHERE b.user.id = :userId "
+          + "AND b.bookedTo > CURRENT_TIMESTAMP "
           + "AND (SELECT bs.status FROM BookingStatus bs WHERE bs.booking = b ORDER BY bs.createdOn DESC LIMIT 1) = 'BOOKED'")
   List<Booking> findActiveBookingsByUserId(@Param("userId") Long userId);
 }

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/booking/request/BookingRequest.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/booking/request/BookingRequest.java
@@ -3,11 +3,11 @@ package com.acs.bookingsystem.booking.request;
 import com.acs.bookingsystem.booking.enums.Room;
 import com.acs.bookingsystem.danceclass.enums.ClassType;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 public record BookingRequest(
     @NotNull Room room,
     @NotNull ClassType classType,
     boolean isShareable,
-    @NotNull LocalDateTime dateFrom,
-    @NotNull LocalDateTime dateTo) {}
+    @NotNull OffsetDateTime dateFrom,
+    @NotNull OffsetDateTime dateTo) {}

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/booking/service/BookingService.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/booking/service/BookingService.java
@@ -16,7 +16,7 @@ import com.acs.bookingsystem.danceclass.service.DanceClassService;
 import com.acs.bookingsystem.payment.PriceCalculator;
 import com.acs.bookingsystem.user.entity.User;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -65,7 +65,7 @@ public class BookingService {
   }
 
   public List<BookingWithStatus> getBookingsByRoomAndDates(
-      Room room, LocalDateTime dateFrom, LocalDateTime dateTo) {
+      Room room, OffsetDateTime dateFrom, OffsetDateTime dateTo) {
     return bookingRepository
         .findActiveBookingsForRoomAndTimeRange(room, null, dateFrom, dateTo)
         .stream()

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/booking/service/validation/BookingTimeValidator.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/booking/service/validation/BookingTimeValidator.java
@@ -4,8 +4,8 @@ import com.acs.bookingsystem.booking.request.BookingRequest;
 import com.acs.bookingsystem.common.exception.model.ErrorCode;
 import java.time.DayOfWeek;
 import java.time.Duration;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
@@ -55,7 +55,7 @@ public class BookingTimeValidator implements BookingValidatorRule {
     return Optional.of(new ValidationFailure(message, ErrorCode.BOOKING_TIME_INVALID));
   }
 
-  private boolean endsBeforeStarts(LocalDateTime dateFrom, LocalDateTime dateTo) {
+  private boolean endsBeforeStarts(OffsetDateTime dateFrom, OffsetDateTime dateTo) {
     return !dateFrom.isBefore(dateTo);
   }
 
@@ -64,7 +64,7 @@ public class BookingTimeValidator implements BookingValidatorRule {
     return duration.compareTo(MINIMUM_BOOKING_TIME) < 0;
   }
 
-  private boolean isInvalidMinuteAlignment(LocalDateTime dateTime) {
+  private boolean isInvalidMinuteAlignment(OffsetDateTime dateTime) {
     return (dateTime.getSecond() != 0
         || dateTime.getNano() != 0
         || dateTime.getMinute() % TIME_INTERVAL.toMinutes() != 0);
@@ -75,11 +75,11 @@ public class BookingTimeValidator implements BookingValidatorRule {
     return duration.toMillis() % TIME_INTERVAL.toMillis() != 0;
   }
 
-  private boolean isNotSameDate(LocalDateTime dateFrom, LocalDateTime dateTo) {
+  private boolean isNotSameDate(OffsetDateTime dateFrom, OffsetDateTime dateTo) {
     return !dateFrom.toLocalDate().equals(dateTo.toLocalDate());
   }
 
-  private boolean isNotWithinOpeningHours(LocalDateTime dateFrom, LocalDateTime dateTo) {
+  private boolean isNotWithinOpeningHours(OffsetDateTime dateFrom, OffsetDateTime dateTo) {
     final DayOfWeek dayOfWeek = dateFrom.getDayOfWeek();
     LocalTime openingTime;
     LocalTime closingTime;
@@ -104,7 +104,7 @@ public class BookingTimeValidator implements BookingValidatorRule {
   }
 
   private boolean validateTimeRange(
-      LocalDateTime date, LocalTime openingTime, LocalTime closingTime) {
+      OffsetDateTime date, LocalTime openingTime, LocalTime closingTime) {
     return date.toLocalTime().isBefore(openingTime) || date.toLocalTime().isAfter(closingTime);
   }
 }

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/booking/service/validation/ShareabilityLimitValidator.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/booking/service/validation/ShareabilityLimitValidator.java
@@ -4,7 +4,7 @@ import com.acs.bookingsystem.booking.entity.Booking;
 import com.acs.bookingsystem.booking.repository.BookingRepository;
 import com.acs.bookingsystem.booking.request.BookingRequest;
 import com.acs.bookingsystem.common.exception.model.ErrorCode;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -46,11 +46,11 @@ public class ShareabilityLimitValidator implements BookingValidatorRule {
 
   private boolean overlapsMaximumShareableBookings(
       List<Booking> shareableBookings, BookingRequest bookingRequest) {
-    LocalDateTime start = bookingRequest.dateFrom();
-    final LocalDateTime end = bookingRequest.dateTo();
+    OffsetDateTime start = bookingRequest.dateFrom();
+    final OffsetDateTime end = bookingRequest.dateTo();
 
     while (start.isBefore(end)) {
-      LocalDateTime slotEnd = start.plusMinutes(TIME_INTERVAL);
+      OffsetDateTime slotEnd = start.plusMinutes(TIME_INTERVAL);
       int overlapCounter = 0;
 
       for (Booking booking : shareableBookings) {
@@ -65,7 +65,7 @@ public class ShareabilityLimitValidator implements BookingValidatorRule {
     return false;
   }
 
-  private boolean bookingsOverlap(LocalDateTime start, LocalDateTime end, Booking booking) {
+  private boolean bookingsOverlap(OffsetDateTime start, OffsetDateTime end, Booking booking) {
     return booking.getBookedFrom().isBefore(end) && booking.getBookedTo().isAfter(start);
   }
 

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/booking/view/dto/BookingDetail.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/booking/view/dto/BookingDetail.java
@@ -4,7 +4,7 @@ import com.acs.bookingsystem.booking.enums.BookingStatusType;
 import com.acs.bookingsystem.booking.enums.Room;
 import com.acs.bookingsystem.danceclass.enums.ClassType;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record BookingDetail(
@@ -14,7 +14,7 @@ public record BookingDetail(
     BookingStatusType status,
     boolean shareable,
     ClassType classType,
-    LocalDateTime dateFrom,
-    LocalDateTime dateTo,
+    OffsetDateTime dateFrom,
+    OffsetDateTime dateTo,
     BigDecimal totalPrice)
     implements BookingView {}

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/booking/view/dto/BookingSummary.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/booking/view/dto/BookingSummary.java
@@ -3,7 +3,7 @@ package com.acs.bookingsystem.booking.view.dto;
 import com.acs.bookingsystem.booking.enums.BookingStatusType;
 import com.acs.bookingsystem.booking.enums.Room;
 import com.acs.bookingsystem.danceclass.enums.ClassType;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record BookingSummary(
@@ -12,6 +12,6 @@ public record BookingSummary(
     ClassType classType,
     BookingStatusType status,
     boolean shareable,
-    LocalDateTime bookedFrom,
-    LocalDateTime bookedTo)
+    OffsetDateTime bookedFrom,
+    OffsetDateTime bookedTo)
     implements BookingView {}

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/payment/Payment.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/payment/Payment.java
@@ -2,7 +2,7 @@ package com.acs.bookingsystem.payment;
 
 import com.acs.bookingsystem.booking.entity.Booking;
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,7 +27,14 @@ public class Payment {
   private PaymentStatus paymentStatus;
 
   @Column(nullable = false)
-  private LocalDateTime createdOn;
+  private Instant createdOn;
+
+  @PrePersist
+  void prePersist() {
+    if (createdOn == null) {
+      createdOn = Instant.now();
+    }
+  }
 
   @ManyToOne
   @JoinColumn(referencedColumnName = "id")

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/payment/PriceCalculator.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/payment/PriceCalculator.java
@@ -6,7 +6,7 @@ import com.acs.bookingsystem.danceclass.entity.DanceClass;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Duration;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -27,7 +27,7 @@ public class PriceCalculator {
    * @throws RequestException if the booking duration is invalid.
    */
   public static BigDecimal calculateTotalPrice(
-      LocalDateTime dateFrom, LocalDateTime dateTo, DanceClass danceClass) {
+      OffsetDateTime dateFrom, OffsetDateTime dateTo, DanceClass danceClass) {
     BigDecimal pricePerHour = danceClass.getPricePerHour();
 
     // todo why to minutes why not leave in hours?

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/security/config/SecurityConfig.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/security/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
     http.csrf(
             AbstractHttpConfigurer
                 ::disable) // Disable CSRF protection for stateless APIs -> not needed if using JWT
-                           // token
+        // token
         .cors(cors -> cors.configurationSource(corsConfigurationSource()))
         .authorizeHttpRequests(
             auth ->
@@ -87,9 +87,8 @@ public class SecurityConfig {
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
     configuration.setAllowedOrigins(
-        List.of(
-            allowedOrigins)); // Only allow requests from our frontend URL (CORS is only for
-                              // browsers, will not block cURLs)
+        List.of(allowedOrigins)); // Only allow requests from our frontend URL (CORS is only for
+    // browsers, will not block cURLs)
     configuration.setAllowedMethods(
         List.of(
             "GET", "POST", "PATCH", "PUT", "DELETE",

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/security/config/SecurityConfig.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/security/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
   private String allowedOrigins;
 
   @Bean
+  @SuppressWarnings("java:S4502") // CSRF safe to disable — stateless JWT API, no session cookies
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http.csrf(
             AbstractHttpConfigurer

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/security/filter/JwtAuthenticationFilter.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/security/filter/JwtAuthenticationFilter.java
@@ -45,7 +45,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       response.setStatus(
           HttpServletResponse
               .SC_UNAUTHORIZED); // Return 401 directly instead of letting Spring Security turn it
-                                 // into a 403
+      // into a 403
       return;
     }
 

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/user/controller/UserAdminController.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/user/controller/UserAdminController.java
@@ -4,6 +4,7 @@ import com.acs.bookingsystem.security.CurrentUser;
 import com.acs.bookingsystem.user.entity.User;
 import com.acs.bookingsystem.user.model.UserProfile;
 import com.acs.bookingsystem.user.request.InviteRequest;
+import com.acs.bookingsystem.user.request.UpdateUserStatusRequest;
 import com.acs.bookingsystem.user.response.InviteResponse;
 import com.acs.bookingsystem.user.response.UserStatusResponse;
 import com.acs.bookingsystem.user.service.UserService;
@@ -39,11 +40,15 @@ public class UserAdminController {
     return ResponseEntity.ok(userService.invite(request));
   }
 
-  @PatchMapping("/{userUid}/status")
+  @PatchMapping("/{userUid}")
   public ResponseEntity<UserStatusResponse> updateUserStatus(
-      @CurrentUser User admin, @PathVariable UUID userUid, @RequestParam boolean enable) {
+      @CurrentUser User admin,
+      @PathVariable UUID userUid,
+      @Valid @RequestBody UpdateUserStatusRequest request) {
     UserStatusResponse response =
-        enable ? userService.enableUser(userUid) : userService.disableUser(userUid, admin);
+        request.enabled()
+            ? userService.enableUser(userUid)
+            : userService.disableUser(userUid, admin);
     return ResponseEntity.ok(response);
   }
 }

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/user/controller/UserAdminController.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/user/controller/UserAdminController.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@SuppressWarnings("java:S4684") // @CurrentUser resolves from security context, not request body
 @RestController
 @RequestMapping("/api/v1/admin/users")
 @RequiredArgsConstructor

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/user/request/UpdateUserStatusRequest.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/user/request/UpdateUserStatusRequest.java
@@ -1,0 +1,6 @@
+package com.acs.bookingsystem.user.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateUserStatusRequest(
+    @NotNull(message = "enabled cannot be null") Boolean enabled) {}

--- a/booking-system-app/src/main/resources/application.yaml
+++ b/booking-system-app/src/main/resources/application.yaml
@@ -2,6 +2,9 @@ spring:
   application:
     name: booking-system
 
+  jackson:
+    time-zone: UTC
+
   jpa:
     hibernate:
       ddl-auto: validate

--- a/booking-system-app/src/main/resources/db/migration/V1__Create_initial_schema.sql
+++ b/booking-system-app/src/main/resources/db/migration/V1__Create_initial_schema.sql
@@ -32,8 +32,8 @@ CREATE TABLE booking (
     room VARCHAR(50) NOT NULL,
     dance_class_id BIGINT NOT NULL,
     shareable BOOLEAN DEFAULT FALSE,
-    booked_from TIMESTAMP NOT NULL,
-    booked_to TIMESTAMP NOT NULL,
+    booked_from TIMESTAMPTZ NOT NULL,
+    booked_to TIMESTAMPTZ NOT NULL,
     total_price DECIMAL(10,2) NOT NULL,
     CONSTRAINT fk_booking_user FOREIGN KEY (user_id) REFERENCES users(id),
     CONSTRAINT fk_booking_dance_class FOREIGN KEY (dance_class_id) REFERENCES dance_class(id)
@@ -43,7 +43,7 @@ CREATE TABLE booking_status (
     id BIGSERIAL PRIMARY KEY,
     booking_id BIGINT NOT NULL,
     status VARCHAR(50) NOT NULL,
-    created_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_on TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     created_by_id BIGINT NOT NULL,
     CONSTRAINT fk_booking_status_booking FOREIGN KEY (booking_id) REFERENCES booking(id),
     CONSTRAINT fk_booking_status_user FOREIGN KEY (created_by_id) REFERENCES users(id)
@@ -53,7 +53,7 @@ CREATE TABLE payment (
     id BIGSERIAL PRIMARY KEY,
     booking_id BIGINT NOT NULL UNIQUE,
     payment_status VARCHAR(50) NOT NULL,
-    created_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_on TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     account_id BIGINT,
     CONSTRAINT fk_payment_booking FOREIGN KEY (booking_id) REFERENCES booking(id),
     CONSTRAINT fk_payment_account FOREIGN KEY (account_id) REFERENCES account(id)
@@ -81,13 +81,16 @@ ALTER TABLE booking ADD CONSTRAINT chk_booking_room
     CHECK (room IN ('ASTAIRE', 'BUSSELL', 'ALEX MOORE', 'FOSSE'));
 
 ALTER TABLE booking_status ADD CONSTRAINT chk_booking_status_type
-    CHECK (status IN ('BOOKED', 'CANCELLED'));
+    CHECK (status IN ('BOOKED', 'CANCELLED', 'COMPLETED'));
 
 CREATE INDEX idx_booking_status_booking_id_created_on
     ON booking_status (booking_id, created_on DESC);
 
 CREATE INDEX idx_booking_room_dates
     ON booking (room, booked_from, booked_to);
+
+CREATE INDEX idx_booking_user_id
+    ON booking (user_id);
 
 ALTER TABLE payment ADD CONSTRAINT chk_payment_status
     CHECK (payment_status IN ('OUTSTANDING', 'PAID', 'VOIDED'));

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/booking/controller/BookingAdminControllerTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/booking/controller/BookingAdminControllerTest.java
@@ -156,6 +156,6 @@ class BookingAdminControllerTest {
         .perform(delete("/api/v1/admin/bookings/{bookingUid}", BOOKING_UID))
         .andExpect(status().isNoContent());
 
-    verify(bookingService).cancelBooking(eq(BOOKING_UID), eq(adminUser));
+    verify(bookingService).cancelBooking(BOOKING_UID, adminUser);
   }
 }

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/booking/controller/BookingAdminControllerTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/booking/controller/BookingAdminControllerTest.java
@@ -27,7 +27,8 @@ import com.acs.bookingsystem.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -75,8 +76,8 @@ class BookingAdminControllerTest {
           BookingStatusType.BOOKED,
           false,
           ClassType.PRIVATE,
-          LocalDateTime.of(2025, 6, 2, 10, 0),
-          LocalDateTime.of(2025, 6, 2, 11, 0),
+          OffsetDateTime.of(2025, 6, 2, 10, 0, 0, 0, ZoneOffset.UTC),
+          OffsetDateTime.of(2025, 6, 2, 11, 0, 0, 0, ZoneOffset.UTC),
           BigDecimal.TEN);
 
   @BeforeEach
@@ -132,8 +133,8 @@ class BookingAdminControllerTest {
             Room.ASTAIRE,
             ClassType.PRIVATE,
             false,
-            LocalDateTime.of(2025, 6, 2, 10, 0),
-            LocalDateTime.of(2025, 6, 2, 11, 0));
+            OffsetDateTime.of(2025, 6, 2, 10, 0, 0, 0, ZoneOffset.UTC),
+            OffsetDateTime.of(2025, 6, 2, 11, 0, 0, 0, ZoneOffset.UTC));
     when(userService.getUserByUid(USER_UID)).thenReturn(adminUser);
     when(bookingService.createBooking(any(BookingRequest.class), any(User.class)))
         .thenReturn(bookingWithStatus);

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/booking/controller/BookingControllerTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/booking/controller/BookingControllerTest.java
@@ -26,7 +26,8 @@ import com.acs.bookingsystem.user.entity.User;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,8 +70,8 @@ class BookingControllerTest {
           BookingStatusType.BOOKED,
           false,
           ClassType.PRIVATE,
-          LocalDateTime.of(2025, 6, 2, 10, 0),
-          LocalDateTime.of(2025, 6, 2, 11, 0),
+          OffsetDateTime.of(2025, 6, 2, 10, 0, 0, 0, ZoneOffset.UTC),
+          OffsetDateTime.of(2025, 6, 2, 11, 0, 0, 0, ZoneOffset.UTC),
           BigDecimal.TEN);
 
   private final BookingSummary bookingSummary =
@@ -80,8 +81,8 @@ class BookingControllerTest {
           ClassType.PRIVATE,
           BookingStatusType.BOOKED,
           false,
-          LocalDateTime.of(2025, 6, 2, 10, 0),
-          LocalDateTime.of(2025, 6, 2, 11, 0));
+          OffsetDateTime.of(2025, 6, 2, 10, 0, 0, 0, ZoneOffset.UTC),
+          OffsetDateTime.of(2025, 6, 2, 11, 0, 0, 0, ZoneOffset.UTC));
 
   @BeforeEach
   void setup() {
@@ -97,8 +98,8 @@ class BookingControllerTest {
             Room.ASTAIRE,
             ClassType.PRIVATE,
             false,
-            LocalDateTime.of(2025, 6, 2, 10, 0),
-            LocalDateTime.of(2025, 6, 2, 11, 0));
+            OffsetDateTime.of(2025, 6, 2, 10, 0, 0, 0, ZoneOffset.UTC),
+            OffsetDateTime.of(2025, 6, 2, 11, 0, 0, 0, ZoneOffset.UTC));
 
     when(bookingService.createBooking(any(BookingRequest.class), any(User.class)))
         .thenReturn(bookingWithStatus);

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/BookingServiceTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/BookingServiceTest.java
@@ -25,7 +25,8 @@ import com.acs.bookingsystem.danceclass.service.DanceClassService;
 import com.acs.bookingsystem.user.entity.User;
 import com.acs.bookingsystem.user.enums.Role;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -78,8 +79,8 @@ class BookingServiceTest {
           Room.ASTAIRE,
           ClassType.PRIVATE,
           false,
-          LocalDateTime.of(2025, 6, 2, 10, 0),
-          LocalDateTime.of(2025, 6, 2, 11, 0));
+          OffsetDateTime.of(2025, 6, 2, 10, 0, 0, 0, ZoneOffset.UTC),
+          OffsetDateTime.of(2025, 6, 2, 11, 0, 0, 0, ZoneOffset.UTC));
 
   private final Booking booking = Booking.builder().uid(BOOKING_UID).user(user).build();
 
@@ -297,8 +298,8 @@ class BookingServiceTest {
 
   @Test
   void givenRoomAndDates_whenGetBookingsByRoomAndDates_thenReturnsBookings() {
-    LocalDateTime from = LocalDateTime.of(2025, 6, 2, 10, 0);
-    LocalDateTime to = LocalDateTime.of(2025, 6, 2, 11, 0);
+    OffsetDateTime from = OffsetDateTime.of(2025, 6, 2, 10, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime to = OffsetDateTime.of(2025, 6, 2, 11, 0, 0, 0, ZoneOffset.UTC);
     when(bookingRepository.findActiveBookingsForRoomAndTimeRange(
             eq(Room.ASTAIRE), eq(null), eq(from), eq(to)))
         .thenReturn(List.of(booking));

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/BookingServiceTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/BookingServiceTest.java
@@ -109,7 +109,7 @@ class BookingServiceTest {
 
     bookingService.createBooking(request, user);
 
-    verify(bookingStatusService).save(eq(booking), eq(user), eq(BookingStatusType.BOOKED));
+    verify(bookingStatusService).save(booking, user, BookingStatusType.BOOKED);
   }
 
   @Test
@@ -169,7 +169,7 @@ class BookingServiceTest {
 
     bookingService.cancelBookingByUserId(BOOKING_UID, USER_ID);
 
-    verify(bookingStatusService).save(eq(booking), eq(user), eq(BookingStatusType.CANCELLED));
+    verify(bookingStatusService).save(booking, user, BookingStatusType.CANCELLED);
   }
 
   @Test
@@ -190,7 +190,7 @@ class BookingServiceTest {
 
     bookingService.cancelBooking(BOOKING_UID, admin);
 
-    verify(bookingStatusService).save(eq(booking), eq(admin), eq(BookingStatusType.CANCELLED));
+    verify(bookingStatusService).save(booking, admin, BookingStatusType.CANCELLED);
   }
 
   @Test
@@ -214,8 +214,8 @@ class BookingServiceTest {
 
     bookingService.cancelAllBookingsByUserId(USER_ID, admin);
 
-    verify(bookingStatusService).save(eq(booking), eq(admin), eq(BookingStatusType.CANCELLED));
-    verify(bookingStatusService).save(eq(booking2), eq(admin), eq(BookingStatusType.CANCELLED));
+    verify(bookingStatusService).save(booking, admin, BookingStatusType.CANCELLED);
+    verify(bookingStatusService).save(booking2, admin, BookingStatusType.CANCELLED);
   }
 
   // --- getBookingByUid ---
@@ -300,8 +300,7 @@ class BookingServiceTest {
   void givenRoomAndDates_whenGetBookingsByRoomAndDates_thenReturnsBookings() {
     OffsetDateTime from = OffsetDateTime.of(2025, 6, 2, 10, 0, 0, 0, ZoneOffset.UTC);
     OffsetDateTime to = OffsetDateTime.of(2025, 6, 2, 11, 0, 0, 0, ZoneOffset.UTC);
-    when(bookingRepository.findActiveBookingsForRoomAndTimeRange(
-            eq(Room.ASTAIRE), eq(null), eq(from), eq(to)))
+    when(bookingRepository.findActiveBookingsForRoomAndTimeRange(Room.ASTAIRE, null, from, to))
         .thenReturn(List.of(booking));
     when(bookingStatusService.resolveStatus(booking)).thenReturn(BookingStatusType.BOOKED);
 

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/validation/BookingTimeValidatorTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/validation/BookingTimeValidatorTest.java
@@ -5,8 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.acs.bookingsystem.booking.enums.Room;
 import com.acs.bookingsystem.booking.request.BookingRequest;
 import com.acs.bookingsystem.danceclass.enums.ClassType;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,8 +25,10 @@ class BookingTimeValidatorTest {
   private static final LocalTime SUN_CLOSE = LocalTime.of(16, 0);
 
   // A valid Monday slot: 10:00–11:00
-  private static final LocalDateTime VALID_START = LocalDateTime.of(2025, 6, 2, 10, 0); // Monday
-  private static final LocalDateTime VALID_END = LocalDateTime.of(2025, 6, 2, 11, 0);
+  private static final OffsetDateTime VALID_START =
+      OffsetDateTime.of(2025, 6, 2, 10, 0, 0, 0, ZoneOffset.UTC); // Monday
+  private static final OffsetDateTime VALID_END =
+      OffsetDateTime.of(2025, 6, 2, 11, 0, 0, 0, ZoneOffset.UTC);
 
   @BeforeEach
   void setup() {
@@ -72,7 +75,7 @@ class BookingTimeValidatorTest {
 
   @Test
   void givenDurationUnder15Minutes_shouldFail() {
-    LocalDateTime end = VALID_START.plusMinutes(10);
+    OffsetDateTime end = VALID_START.plusMinutes(10);
     Optional<ValidationFailure> result = validator.validate(request(VALID_START, end));
     assertThat(result).isPresent();
     assertThat(result.get().message()).contains("minimum of 15 minutes");
@@ -80,15 +83,15 @@ class BookingTimeValidatorTest {
 
   @Test
   void givenDurationExactly15Minutes_shouldPass() {
-    LocalDateTime end = VALID_START.plusMinutes(15);
+    OffsetDateTime end = VALID_START.plusMinutes(15);
     Optional<ValidationFailure> result = validator.validate(request(VALID_START, end));
     assertThat(result).isEmpty();
   }
 
   @Test
   void givenStartNotOnFiveMinuteInterval_shouldFail() {
-    LocalDateTime misalignedStart = LocalDateTime.of(2025, 6, 2, 10, 3);
-    LocalDateTime end = misalignedStart.plusMinutes(15);
+    OffsetDateTime misalignedStart = OffsetDateTime.of(2025, 6, 2, 10, 3, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime end = misalignedStart.plusMinutes(15);
     Optional<ValidationFailure> result = validator.validate(request(misalignedStart, end));
     assertThat(result).isPresent();
     assertThat(result.get().message()).contains("start time");
@@ -96,8 +99,8 @@ class BookingTimeValidatorTest {
 
   @Test
   void givenStartWithSeconds_shouldFail() {
-    LocalDateTime startWithSeconds = LocalDateTime.of(2025, 6, 2, 10, 0, 30);
-    LocalDateTime end = startWithSeconds.plusMinutes(15);
+    OffsetDateTime startWithSeconds = OffsetDateTime.of(2025, 6, 2, 10, 0, 30, 0, ZoneOffset.UTC);
+    OffsetDateTime end = startWithSeconds.plusMinutes(15);
     Optional<ValidationFailure> result = validator.validate(request(startWithSeconds, end));
     assertThat(result).isPresent();
     assertThat(result.get().message()).contains("start time");
@@ -105,7 +108,7 @@ class BookingTimeValidatorTest {
 
   @Test
   void givenEndNotOnFiveMinuteInterval_shouldFail() {
-    LocalDateTime end = LocalDateTime.of(2025, 6, 2, 10, 17);
+    OffsetDateTime end = OffsetDateTime.of(2025, 6, 2, 10, 17, 0, 0, ZoneOffset.UTC);
     Optional<ValidationFailure> result = validator.validate(request(VALID_START, end));
     assertThat(result).isPresent();
     assertThat(result.get().message()).contains("end time");
@@ -113,8 +116,8 @@ class BookingTimeValidatorTest {
 
   @Test
   void givenBookingSpanningMidnight_shouldFail() {
-    LocalDateTime start = LocalDateTime.of(2025, 6, 2, 21, 0);
-    LocalDateTime end = LocalDateTime.of(2025, 6, 3, 9, 0);
+    OffsetDateTime start = OffsetDateTime.of(2025, 6, 2, 21, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime end = OffsetDateTime.of(2025, 6, 3, 9, 0, 0, 0, ZoneOffset.UTC);
     Optional<ValidationFailure> result = validator.validate(request(start, end));
     assertThat(result).isPresent();
     assertThat(result.get().message()).contains("same day");
@@ -122,8 +125,8 @@ class BookingTimeValidatorTest {
 
   @Test
   void givenBookingBeforeOpeningHours_shouldFail() {
-    LocalDateTime start = LocalDateTime.of(2025, 6, 2, 7, 0);
-    LocalDateTime end = LocalDateTime.of(2025, 6, 2, 8, 0);
+    OffsetDateTime start = OffsetDateTime.of(2025, 6, 2, 7, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime end = OffsetDateTime.of(2025, 6, 2, 8, 0, 0, 0, ZoneOffset.UTC);
     Optional<ValidationFailure> result = validator.validate(request(start, end));
     assertThat(result).isPresent();
     assertThat(result.get().message()).contains("opening hours");
@@ -131,8 +134,8 @@ class BookingTimeValidatorTest {
 
   @Test
   void givenBookingAfterClosingHours_shouldFail() {
-    LocalDateTime start = LocalDateTime.of(2025, 6, 2, 22, 0);
-    LocalDateTime end = LocalDateTime.of(2025, 6, 2, 23, 0);
+    OffsetDateTime start = OffsetDateTime.of(2025, 6, 2, 22, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime end = OffsetDateTime.of(2025, 6, 2, 23, 0, 0, 0, ZoneOffset.UTC);
     Optional<ValidationFailure> result = validator.validate(request(start, end));
     assertThat(result).isPresent();
     assertThat(result.get().message()).contains("opening hours");
@@ -140,16 +143,17 @@ class BookingTimeValidatorTest {
 
   @Test
   void givenValidSaturdayBooking_shouldPass() {
-    LocalDateTime start = LocalDateTime.of(2025, 6, 7, 10, 0); // Saturday
-    LocalDateTime end = LocalDateTime.of(2025, 6, 7, 11, 0);
+    OffsetDateTime start = OffsetDateTime.of(2025, 6, 7, 10, 0, 0, 0, ZoneOffset.UTC); // Saturday
+    OffsetDateTime end = OffsetDateTime.of(2025, 6, 7, 11, 0, 0, 0, ZoneOffset.UTC);
     Optional<ValidationFailure> result = validator.validate(request(start, end));
     assertThat(result).isEmpty();
   }
 
   @Test
   void givenSaturdayBookingAfterClosing_shouldFail() {
-    LocalDateTime start = LocalDateTime.of(2025, 6, 7, 18, 0); // Saturday at closing
-    LocalDateTime end = LocalDateTime.of(2025, 6, 7, 19, 0);
+    OffsetDateTime start =
+        OffsetDateTime.of(2025, 6, 7, 18, 0, 0, 0, ZoneOffset.UTC); // Saturday at closing
+    OffsetDateTime end = OffsetDateTime.of(2025, 6, 7, 19, 0, 0, 0, ZoneOffset.UTC);
     Optional<ValidationFailure> result = validator.validate(request(start, end));
     assertThat(result).isPresent();
     assertThat(result.get().message()).contains("opening hours");
@@ -157,13 +161,13 @@ class BookingTimeValidatorTest {
 
   @Test
   void givenValidSundayBooking_shouldPass() {
-    LocalDateTime start = LocalDateTime.of(2025, 6, 8, 10, 0); // Sunday
-    LocalDateTime end = LocalDateTime.of(2025, 6, 8, 11, 0);
+    OffsetDateTime start = OffsetDateTime.of(2025, 6, 8, 10, 0, 0, 0, ZoneOffset.UTC); // Sunday
+    OffsetDateTime end = OffsetDateTime.of(2025, 6, 8, 11, 0, 0, 0, ZoneOffset.UTC);
     Optional<ValidationFailure> result = validator.validate(request(start, end));
     assertThat(result).isEmpty();
   }
 
-  private BookingRequest request(LocalDateTime from, LocalDateTime to) {
+  private BookingRequest request(OffsetDateTime from, OffsetDateTime to) {
     return new BookingRequest(Room.ASTAIRE, ClassType.PRIVATE, false, from, to);
   }
 }

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/validation/BookingValidatorTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/validation/BookingValidatorTest.java
@@ -12,8 +12,9 @@ import com.acs.bookingsystem.booking.repository.BookingRepository;
 import com.acs.bookingsystem.booking.request.BookingRequest;
 import com.acs.bookingsystem.common.exception.model.ErrorCode;
 import com.acs.bookingsystem.danceclass.enums.ClassType;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,8 +30,10 @@ class BookingValidatorTest {
 
   private BookingValidator validator;
 
-  private static final LocalDateTime VALID_START = LocalDateTime.of(2025, 6, 2, 10, 0);
-  private static final LocalDateTime VALID_END = LocalDateTime.of(2025, 6, 2, 11, 0);
+  private static final OffsetDateTime VALID_START =
+      OffsetDateTime.of(2025, 6, 2, 10, 0, 0, 0, ZoneOffset.UTC);
+  private static final OffsetDateTime VALID_END =
+      OffsetDateTime.of(2025, 6, 2, 11, 0, 0, 0, ZoneOffset.UTC);
 
   @BeforeEach
   void setup() {
@@ -66,7 +69,7 @@ class BookingValidatorTest {
 
   @Test
   void givenInvalidTime_shouldFailWithTimeErrorAndNotHitDatabase() {
-    LocalDateTime invalidEnd = VALID_START.minusHours(1);
+    OffsetDateTime invalidEnd = VALID_START.minusHours(1);
 
     Optional<ValidationFailure> result = validator.validate(request(VALID_START, invalidEnd));
 
@@ -92,7 +95,7 @@ class BookingValidatorTest {
     return request(VALID_START, VALID_END);
   }
 
-  private BookingRequest request(LocalDateTime from, LocalDateTime to) {
+  private BookingRequest request(OffsetDateTime from, OffsetDateTime to) {
     return new BookingRequest(Room.ASTAIRE, ClassType.PRIVATE, false, from, to);
   }
 }

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/validation/NonShareableConflictValidatorTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/validation/NonShareableConflictValidatorTest.java
@@ -11,7 +11,8 @@ import com.acs.bookingsystem.booking.repository.BookingRepository;
 import com.acs.bookingsystem.booking.request.BookingRequest;
 import com.acs.bookingsystem.common.exception.model.ErrorCode;
 import com.acs.bookingsystem.danceclass.enums.ClassType;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,8 +28,10 @@ class NonShareableConflictValidatorTest {
 
   private NonShareableConflictValidator validator;
 
-  private static final LocalDateTime START = LocalDateTime.of(2025, 6, 2, 10, 0);
-  private static final LocalDateTime END = LocalDateTime.of(2025, 6, 2, 11, 0);
+  private static final OffsetDateTime START =
+      OffsetDateTime.of(2025, 6, 2, 10, 0, 0, 0, ZoneOffset.UTC);
+  private static final OffsetDateTime END =
+      OffsetDateTime.of(2025, 6, 2, 11, 0, 0, 0, ZoneOffset.UTC);
 
   @BeforeEach
   void setup() {

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/validation/ShareabilityLimitValidatorTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/validation/ShareabilityLimitValidatorTest.java
@@ -11,7 +11,8 @@ import com.acs.bookingsystem.booking.repository.BookingRepository;
 import com.acs.bookingsystem.booking.request.BookingRequest;
 import com.acs.bookingsystem.common.exception.model.ErrorCode;
 import com.acs.bookingsystem.danceclass.enums.ClassType;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,8 +28,10 @@ class ShareabilityLimitValidatorTest {
 
   private ShareabilityLimitValidator validator;
 
-  private static final LocalDateTime START = LocalDateTime.of(2025, 6, 2, 10, 0);
-  private static final LocalDateTime END = LocalDateTime.of(2025, 6, 2, 11, 0);
+  private static final OffsetDateTime START =
+      OffsetDateTime.of(2025, 6, 2, 10, 0, 0, 0, ZoneOffset.UTC);
+  private static final OffsetDateTime END =
+      OffsetDateTime.of(2025, 6, 2, 11, 0, 0, 0, ZoneOffset.UTC);
 
   @BeforeEach
   void setup() {
@@ -126,7 +129,7 @@ class ShareabilityLimitValidatorTest {
     return new BookingRequest(Room.ASTAIRE, ClassType.PRIVATE, false, START, END);
   }
 
-  private Booking shareableBooking(LocalDateTime from, LocalDateTime to) {
+  private Booking shareableBooking(OffsetDateTime from, OffsetDateTime to) {
     return Booking.builder()
         .room(Room.ASTAIRE)
         .shareable(true)

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/booking/view/BookingMapperTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/booking/view/BookingMapperTest.java
@@ -14,6 +14,8 @@ import com.acs.bookingsystem.user.enums.Role;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,8 +26,10 @@ class BookingMapperTest {
 
   private static final UUID BOOKING_UID = UUID.randomUUID();
   private static final UUID USER_UID = UUID.randomUUID();
-  private static final LocalDateTime FROM = LocalDateTime.of(2025, Month.JUNE, 2, 10, 0);
-  private static final LocalDateTime TO = LocalDateTime.of(2025, Month.JUNE, 2, 11, 0);
+  private static final OffsetDateTime FROM =
+      LocalDateTime.of(2025, Month.JUNE, 2, 10, 0).atOffset(ZoneOffset.UTC);
+  private static final OffsetDateTime TO =
+      LocalDateTime.of(2025, Month.JUNE, 2, 11, 0).atOffset(ZoneOffset.UTC);
 
   private Booking booking;
 

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/payment/PriceCalculatorTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/payment/PriceCalculatorTest.java
@@ -7,6 +7,8 @@ import com.acs.bookingsystem.danceclass.entity.DanceClass;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -22,8 +24,8 @@ class PriceCalculatorTest {
     "'2024-11-12T14:30:00', '25.0'" // 2.5 hours
   })
   void calculateTotalPrice_forValidTimeSlots(String endDateTimeStr, String expectedPriceStr) {
-    LocalDateTime start = getStart();
-    LocalDateTime end = LocalDateTime.parse(endDateTimeStr);
+    OffsetDateTime start = getStart();
+    OffsetDateTime end = LocalDateTime.parse(endDateTimeStr).atOffset(ZoneOffset.UTC);
     BigDecimal expectedPrice = new BigDecimal(expectedPriceStr);
 
     BigDecimal actualPrice = PriceCalculator.calculateTotalPrice(start, end, danceClass);
@@ -31,7 +33,7 @@ class PriceCalculatorTest {
     assertEquals(0, expectedPrice.compareTo(actualPrice));
   }
 
-  private LocalDateTime getStart() {
-    return LocalDateTime.of(2024, Month.NOVEMBER, 12, 12, 0, 0);
+  private OffsetDateTime getStart() {
+    return LocalDateTime.of(2024, Month.NOVEMBER, 12, 12, 0).atOffset(ZoneOffset.UTC);
   }
 }

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/user/controller/UserAdminControllerTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/user/controller/UserAdminControllerTest.java
@@ -13,6 +13,7 @@ import com.acs.bookingsystem.user.UserTestData;
 import com.acs.bookingsystem.user.entity.User;
 import com.acs.bookingsystem.user.model.UserProfile;
 import com.acs.bookingsystem.user.request.InviteRequest;
+import com.acs.bookingsystem.user.request.UpdateUserStatusRequest;
 import com.acs.bookingsystem.user.response.InviteResponse;
 import com.acs.bookingsystem.user.response.UserStatusResponse;
 import com.acs.bookingsystem.user.service.AuthenticationService;
@@ -127,8 +128,9 @@ class UserAdminControllerTest {
 
     mockMvc
         .perform(
-            patch("/api/v1/admin/users/{userUid}/status", UserTestData.ADMIN_UUID)
-                .param("enable", "true"))
+            patch("/api/v1/admin/users/{userUid}", UserTestData.ADMIN_UUID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new UpdateUserStatusRequest(true))))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.enabled").value(true));
 
@@ -148,8 +150,9 @@ class UserAdminControllerTest {
 
     mockMvc
         .perform(
-            patch("/api/v1/admin/users/{userUid}/status", UserTestData.ADMIN_UUID)
-                .param("enable", "false"))
+            patch("/api/v1/admin/users/{userUid}", UserTestData.ADMIN_UUID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new UpdateUserStatusRequest(false))))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.enabled").value(false));
 
@@ -158,15 +161,18 @@ class UserAdminControllerTest {
   }
 
   @Test
-  void givenMissingEnableParam_whenUpdateUserStatus_thenReturn400() throws Exception {
+  void givenNullEnabled_whenUpdateUserStatus_thenReturn400() throws Exception {
     SecurityContextHolder.getContext()
         .setAuthentication(
             new UsernamePasswordAuthenticationToken(adminUser, null, adminUser.getAuthorities()));
 
     mockMvc
-        .perform(patch("/api/v1/admin/users/{userUid}/status", UserTestData.ADMIN_UUID))
+        .perform(
+            patch("/api/v1/admin/users/{userUid}", UserTestData.ADMIN_UUID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"enabled\":null}"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"))
-        .andExpect(jsonPath("$.details[0].field").value("enable"));
+        .andExpect(jsonPath("$.details[0].field").value("enabled"));
   }
 }

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/user/controller/UserAdminControllerTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/user/controller/UserAdminControllerTest.java
@@ -1,6 +1,5 @@
 package com.acs.bookingsystem.user.controller;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -146,7 +145,7 @@ class UserAdminControllerTest {
 
     UserStatusResponse response =
         UserStatusResponse.builder().uid(UserTestData.ADMIN_UUID).enabled(false).build();
-    when(userService.disableUser(eq(UserTestData.ADMIN_UUID), eq(adminUser))).thenReturn(response);
+    when(userService.disableUser(UserTestData.ADMIN_UUID, adminUser)).thenReturn(response);
 
     mockMvc
         .perform(
@@ -156,7 +155,7 @@ class UserAdminControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.enabled").value(false));
 
-    verify(userService).disableUser(eq(UserTestData.ADMIN_UUID), eq(adminUser));
+    verify(userService).disableUser(UserTestData.ADMIN_UUID, adminUser);
     verify(userService, never()).enableUser(UserTestData.ADMIN_UUID);
   }
 

--- a/booking-system-it/src/test/java/com/acs/bookingsystem/booking/repository/BookingRepositoryIT.java
+++ b/booking-system-it/src/test/java/com/acs/bookingsystem/booking/repository/BookingRepositoryIT.java
@@ -207,8 +207,7 @@ class BookingRepositoryIT extends BaseIntegrationTest {
     List<Booking> shareableOnly =
         bookingRepository.findActiveBookingsForRoomAndTimeRange(Room.ASTAIRE, true, FROM, TO);
 
-    assertThat(shareableOnly).allMatch(Booking::isShareable);
-    assertThat(shareableOnly).hasSize(1);
+    assertThat(shareableOnly).hasSize(1).allMatch(Booking::isShareable);
   }
 
   @Test

--- a/booking-system-it/src/test/java/com/acs/bookingsystem/booking/repository/BookingRepositoryIT.java
+++ b/booking-system-it/src/test/java/com/acs/bookingsystem/booking/repository/BookingRepositoryIT.java
@@ -14,8 +14,11 @@ import com.acs.bookingsystem.user.entity.User;
 import com.acs.bookingsystem.user.enums.Role;
 import com.acs.bookingsystem.user.repository.UserRepository;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,8 +34,8 @@ class BookingRepositoryIT extends BaseIntegrationTest {
   @Autowired private UserRepository userRepository;
   @Autowired private DanceClassRepository danceClassRepository;
 
-  private static final LocalDateTime FROM = LocalDateTime.of(2025, Month.JUNE, 2, 10, 0);
-  private static final LocalDateTime TO = LocalDateTime.of(2025, Month.JUNE, 2, 11, 0);
+  private static final OffsetDateTime FROM = LocalDateTime.of(2025, Month.JUNE, 2, 10, 0).atOffset(ZoneOffset.UTC);
+  private static final OffsetDateTime TO = LocalDateTime.of(2025, Month.JUNE, 2, 11, 0).atOffset(ZoneOffset.UTC);
 
   private User user;
   private DanceClass danceClass;
@@ -186,8 +189,8 @@ class BookingRepositoryIT extends BaseIntegrationTest {
 
   @Test
   void findActiveBookingsForRoomAndTimeRange_excludesNonOverlappingBookings() {
-    LocalDateTime before = LocalDateTime.of(2025, Month.JUNE, 2, 8, 0);
-    LocalDateTime beforeEnd = LocalDateTime.of(2025, Month.JUNE, 2, 9, 0);
+    OffsetDateTime before = LocalDateTime.of(2025, Month.JUNE, 2, 8, 0).atOffset(ZoneOffset.UTC);
+    OffsetDateTime beforeEnd = LocalDateTime.of(2025, Month.JUNE, 2, 9, 0).atOffset(ZoneOffset.UTC);
     saveBookingWithStatus(Room.ASTAIRE, false, before, beforeEnd, BookingStatusType.BOOKED);
 
     List<Booking> result =
@@ -211,9 +214,8 @@ class BookingRepositoryIT extends BaseIntegrationTest {
   @Test
   void findActiveBookingsForRoomAndTimeRange_returnsLatestStatusPerBooking() {
     Booking booking = saveBooking(Room.ASTAIRE, false, FROM, TO);
-    saveStatus(booking, BookingStatusType.BOOKED, LocalDateTime.of(2025, Month.JANUARY, 1, 10, 0));
-    saveStatus(
-        booking, BookingStatusType.CANCELLED, LocalDateTime.of(2025, Month.JANUARY, 1, 11, 0));
+    saveStatus(booking, BookingStatusType.BOOKED, Instant.parse("2025-01-01T10:00:00Z"));
+    saveStatus(booking, BookingStatusType.CANCELLED, Instant.parse("2025-01-01T11:00:00Z"));
 
     List<Booking> result =
         bookingRepository.findActiveBookingsForRoomAndTimeRange(Room.ASTAIRE, null, FROM, TO);
@@ -221,18 +223,63 @@ class BookingRepositoryIT extends BaseIntegrationTest {
     assertThat(result).isEmpty();
   }
 
+  // --- findActiveBookingsByUserId ---
+
+  @Test
+  void findActiveBookingsByUserId_returnsUpcomingBookedBooking() {
+    OffsetDateTime future = OffsetDateTime.now(ZoneOffset.UTC).plusDays(1);
+    Booking booking =
+        saveBookingWithStatus(
+            Room.ASTAIRE, false, future, future.plusHours(1), BookingStatusType.BOOKED);
+
+    List<Booking> result = bookingRepository.findActiveBookingsByUserId(user.getId());
+
+    assertThat(result).extracting(Booking::getUid).containsExactly(booking.getUid());
+  }
+
+  @Test
+  void findActiveBookingsByUserId_excludesPastBookedBooking() {
+    OffsetDateTime future = OffsetDateTime.now(ZoneOffset.UTC).plusDays(1);
+    Booking upcoming =
+        saveBookingWithStatus(
+            Room.ASTAIRE, false, future, future.plusHours(1), BookingStatusType.BOOKED);
+    saveBookingWithStatus(Room.BUSSELL, false, FROM, TO, BookingStatusType.BOOKED);
+
+    List<Booking> result = bookingRepository.findActiveBookingsByUserId(user.getId());
+
+    assertThat(result).extracting(Booking::getUid).containsExactly(upcoming.getUid());
+  }
+
+  @Test
+  void findActiveBookingsByUserId_excludesCancelledUpcomingBooking() {
+    OffsetDateTime future = OffsetDateTime.now(ZoneOffset.UTC).plusDays(1);
+    Booking upcoming =
+        saveBookingWithStatus(
+            Room.ASTAIRE, false, future, future.plusHours(1), BookingStatusType.BOOKED);
+    saveBookingWithStatus(
+        Room.BUSSELL,
+        false,
+        future.plusDays(1),
+        future.plusDays(1).plusHours(1),
+        BookingStatusType.CANCELLED);
+
+    List<Booking> result = bookingRepository.findActiveBookingsByUserId(user.getId());
+
+    assertThat(result).extracting(Booking::getUid).containsExactly(upcoming.getUid());
+  }
+
   private Booking saveBookingWithStatus(
       Room room,
       boolean shareable,
-      LocalDateTime from,
-      LocalDateTime to,
+      OffsetDateTime from,
+      OffsetDateTime to,
       BookingStatusType statusType) {
     Booking booking = saveBooking(room, shareable, from, to);
-    saveStatus(booking, statusType, LocalDateTime.now());
+    saveStatus(booking, statusType, Instant.now());
     return booking;
   }
 
-  private Booking saveBooking(Room room, boolean shareable, LocalDateTime from, LocalDateTime to) {
+  private Booking saveBooking(Room room, boolean shareable, OffsetDateTime from, OffsetDateTime to) {
     return bookingRepository.save(
         Booking.builder()
             .uid(UUID.randomUUID())
@@ -246,7 +293,7 @@ class BookingRepositoryIT extends BaseIntegrationTest {
             .build());
   }
 
-  private void saveStatus(Booking booking, BookingStatusType type, LocalDateTime createdOn) {
+  private void saveStatus(Booking booking, BookingStatusType type, Instant createdOn) {
     bookingStatusRepository.save(
         BookingStatus.builder()
             .booking(booking)

--- a/booking-system-it/src/test/java/com/acs/bookingsystem/booking/repository/BookingStatusRepositoryIT.java
+++ b/booking-system-it/src/test/java/com/acs/bookingsystem/booking/repository/BookingStatusRepositoryIT.java
@@ -14,8 +14,11 @@ import com.acs.bookingsystem.user.entity.User;
 import com.acs.bookingsystem.user.enums.Role;
 import com.acs.bookingsystem.user.repository.UserRepository;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,8 +61,8 @@ class BookingStatusRepositoryIT extends BaseIntegrationTest {
                 .room(Room.ASTAIRE)
                 .danceClass(danceClass)
                 .shareable(false)
-                .bookedFrom(LocalDateTime.of(2025, Month.JUNE, 2, 10, 0))
-                .bookedTo(LocalDateTime.of(2025, Month.JUNE, 2, 11, 0))
+                .bookedFrom(LocalDateTime.of(2025, Month.JUNE, 2, 10, 0).atOffset(ZoneOffset.UTC))
+                .bookedTo(LocalDateTime.of(2025, Month.JUNE, 2, 11, 0).atOffset(ZoneOffset.UTC))
                 .totalPrice(BigDecimal.TEN)
                 .build());
   }
@@ -74,7 +77,7 @@ class BookingStatusRepositoryIT extends BaseIntegrationTest {
 
   @Test
   void findLatestStatusByBookingId_returnsSingleStatus() {
-    saveStatus(BookingStatusType.BOOKED, LocalDateTime.of(2025, Month.JANUARY, 1, 10, 0));
+    saveStatus(BookingStatusType.BOOKED, Instant.parse("2025-01-01T10:00:00Z"));
 
     Optional<BookingStatusType> result =
         bookingStatusRepository.findLatestStatusByBookingId(booking.getId());
@@ -84,8 +87,8 @@ class BookingStatusRepositoryIT extends BaseIntegrationTest {
 
   @Test
   void findLatestStatusByBookingId_returnsLatestWhenMultipleExist() {
-    saveStatus(BookingStatusType.BOOKED, LocalDateTime.of(2025, Month.JANUARY, 1, 10, 0));
-    saveStatus(BookingStatusType.CANCELLED, LocalDateTime.of(2025, Month.JANUARY, 1, 11, 0));
+    saveStatus(BookingStatusType.BOOKED, Instant.parse("2025-01-01T10:00:00Z"));
+    saveStatus(BookingStatusType.CANCELLED, Instant.parse("2025-01-01T11:00:00Z"));
 
     Optional<BookingStatusType> result =
         bookingStatusRepository.findLatestStatusByBookingId(booking.getId());
@@ -95,8 +98,8 @@ class BookingStatusRepositoryIT extends BaseIntegrationTest {
 
   @Test
   void findLatestByBookingId_returnsFullStatusEntity() {
-    saveStatus(BookingStatusType.BOOKED, LocalDateTime.of(2025, Month.JANUARY, 1, 10, 0));
-    saveStatus(BookingStatusType.CANCELLED, LocalDateTime.of(2025, Month.JANUARY, 1, 11, 0));
+    saveStatus(BookingStatusType.BOOKED, Instant.parse("2025-01-01T10:00:00Z"));
+    saveStatus(BookingStatusType.CANCELLED, Instant.parse("2025-01-01T11:00:00Z"));
 
     Optional<BookingStatus> result = bookingStatusRepository.findLatestByBookingId(booking.getId());
 
@@ -105,7 +108,7 @@ class BookingStatusRepositoryIT extends BaseIntegrationTest {
     assertThat(result.get().getCreatedBy().getId()).isEqualTo(user.getId());
   }
 
-  private void saveStatus(BookingStatusType type, LocalDateTime createdOn) {
+  private void saveStatus(BookingStatusType type, Instant createdOn) {
     bookingStatusRepository.save(
         BookingStatus.builder()
             .booking(booking)


### PR DESCRIPTION
…fsetDateTime/Instant, add COMPLETED status

- Fix findActiveBookingsByUserId to filter by booked_to > CURRENT_TIMESTAMP so past bookings are not cancelled on user deactivation
- Add COMPLETED to BookingStatusType and schema CHECK constraint
- Add idx_booking_user_id index on booking.user_id
- Migrate booked_from/booked_to from TIMESTAMP to TIMESTAMPTZ (OffsetDateTime in Java)
- Migrate booking_status.created_on and payment.created_on to TIMESTAMPTZ (Instant in Java)
- Set JVM default timezone to UTC on startup and configure Jackson serialization to UTC
- Refactor user status endpoint from PATCH /{uid}/status?enable= to PATCH /{uid} with request body
- Add integration tests for findActiveBookingsByUserId covering past/cancelled exclusion