### PR TITLE
Fix NPE on invited user auth and closing time boundary in booking val…

### DIFF
--- a/booking-system-app/src/main/java/com/acs/bookingsystem/booking/service/validation/BookingTimeValidator.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/booking/service/validation/BookingTimeValidator.java
@@ -99,12 +99,10 @@ public class BookingTimeValidator implements BookingValidatorRule {
       }
     }
 
-    return validateTimeRange(dateFrom, openingTime, closingTime)
-        || validateTimeRange(dateTo, openingTime, closingTime);
-  }
-
-  private boolean validateTimeRange(
-      OffsetDateTime date, LocalTime openingTime, LocalTime closingTime) {
-    return date.toLocalTime().isBefore(openingTime) || date.toLocalTime().isAfter(closingTime);
+    LocalTime start = dateFrom.toLocalTime();
+    LocalTime end = dateTo.toLocalTime();
+    boolean invalidStart = start.isBefore(openingTime) || !start.isBefore(closingTime);
+    boolean invalidEnd = end.isBefore(openingTime) || end.isAfter(closingTime);
+    return invalidStart || invalidEnd;
   }
 }

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/user/entity/User.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/user/entity/User.java
@@ -38,9 +38,11 @@ public class User implements UserDetails {
   @Enumerated(EnumType.STRING)
   private Role role;
 
-  private Boolean locked;
+  @Column(nullable = false)
+  private boolean locked;
 
-  private Boolean enabled;
+  @Column(nullable = false)
+  private boolean enabled;
 
   @Column(length = 50)
   private String firstName;

--- a/booking-system-app/src/main/resources/db/migration/V1__Create_initial_schema.sql
+++ b/booking-system-app/src/main/resources/db/migration/V1__Create_initial_schema.sql
@@ -5,8 +5,8 @@ CREATE TABLE users (
     email VARCHAR(255) NOT NULL UNIQUE,
     password VARCHAR(255),
     role VARCHAR(50) NOT NULL,
-    locked BOOLEAN DEFAULT FALSE,
-    enabled BOOLEAN DEFAULT FALSE,
+    locked BOOLEAN NOT NULL DEFAULT FALSE,
+    enabled BOOLEAN NOT NULL DEFAULT FALSE,
     first_name VARCHAR(50),
     last_name VARCHAR(50),
     phone_number VARCHAR(11)

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/validation/BookingTimeValidatorTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/booking/service/validation/BookingTimeValidatorTest.java
@@ -167,6 +167,35 @@ class BookingTimeValidatorTest {
     assertThat(result).isEmpty();
   }
 
+  @Test
+  void givenBookingStartingAtClosingTime_shouldFail() {
+    OffsetDateTime start =
+        OffsetDateTime.of(2025, 6, 2, 22, 0, 0, 0, ZoneOffset.UTC); // weekday close
+    OffsetDateTime end = OffsetDateTime.of(2025, 6, 2, 22, 15, 0, 0, ZoneOffset.UTC);
+    Optional<ValidationFailure> result = validator.validate(request(start, end));
+    assertThat(result).isPresent();
+    assertThat(result.get().message()).contains("opening hours");
+  }
+
+  @Test
+  void givenBookingEndingAtClosingTime_shouldPass() {
+    OffsetDateTime start = OffsetDateTime.of(2025, 6, 2, 21, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime end =
+        OffsetDateTime.of(2025, 6, 2, 22, 0, 0, 0, ZoneOffset.UTC); // weekday close
+    Optional<ValidationFailure> result = validator.validate(request(start, end));
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void givenSaturdayBookingStartingAtClosingTime_shouldFail() {
+    OffsetDateTime start =
+        OffsetDateTime.of(2025, 6, 7, 18, 0, 0, 0, ZoneOffset.UTC); // Saturday close
+    OffsetDateTime end = OffsetDateTime.of(2025, 6, 7, 18, 15, 0, 0, ZoneOffset.UTC);
+    Optional<ValidationFailure> result = validator.validate(request(start, end));
+    assertThat(result).isPresent();
+    assertThat(result.get().message()).contains("opening hours");
+  }
+
   private BookingRequest request(OffsetDateTime from, OffsetDateTime to) {
     return new BookingRequest(Room.ASTAIRE, ClassType.PRIVATE, false, from, to);
   }

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/user/service/UserServiceTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/user/service/UserServiceTest.java
@@ -150,7 +150,7 @@ class UserServiceTest {
     assertThat(result.getLastName()).isEqualTo("User");
     assertThat(result.getPhoneNumber()).isEqualTo("07123456789");
     assertThat(result.isEnabled()).isTrue();
-    assertThat(result.getLocked()).isFalse();
+    assertThat(result.isLocked()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
…idation

- Change Boolean locked/enabled to boolean primitives in User entity so invited users get locked=false/enabled=false instead of null, preventing NPE when Spring Security calls isAccountNonLocked() during login attempts
- Add NOT NULL to locked/enabled schema columns to enforce at DB level
- Fix BookingTimeValidator to reject bookings starting at or after closing time (previously only rejected if strictly after; end time can still equal closing)
- Add tests for start-at-closing (fail) and end-at-closing (pass) boundaries