### PR TITLE
BOO-5: Replace plaintext password reset with token-based flow

### DIFF
--- a/booking-system-app/src/main/java/com/acs/bookingsystem/common/email/EmailService.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/common/email/EmailService.java
@@ -14,14 +14,16 @@ import org.springframework.stereotype.Service;
 @Service
 @AllArgsConstructor
 public class EmailService {
+  private static final String RESET_LINK_PLACEHOLDER = "{link}";
+
   private final EmailProperties emailProperties;
   private final Mailer mailer;
   private static final Logger LOG = LoggerFactory.getLogger(EmailService.class);
 
-  public void sendPasswordResetEmail(String recipientEmail, String newPassword) {
+  public void sendPasswordResetEmail(String recipientEmail, String resetLink) {
     EmailProperties.Template template = emailProperties.getTemplate().get(RESET_PASSWORD.getKey());
     String subject = template.getSubject();
-    String body = template.getBody().replace("{password}", newPassword);
+    String body = template.getBody().replace(RESET_LINK_PLACEHOLDER, resetLink);
     sendEmail(recipientEmail, subject, body);
   }
 

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/security/model/PasswordResetClaims.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/security/model/PasswordResetClaims.java
@@ -1,0 +1,3 @@
+package com.acs.bookingsystem.security.model;
+
+public record PasswordResetClaims(String email, String passwordHash) {}

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/security/util/JwtUtil.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/security/util/JwtUtil.java
@@ -2,6 +2,7 @@ package com.acs.bookingsystem.security.util;
 
 import com.acs.bookingsystem.common.exception.AuthorizationException;
 import com.acs.bookingsystem.common.exception.model.ErrorCode;
+import com.acs.bookingsystem.security.model.PasswordResetClaims;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -20,6 +21,14 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class JwtUtil {
+  private static final long AUTH_TOKEN_EXPIRY_MS = 1000L * 60 * 60 * 24;
+  private static final long PASSWORD_RESET_TOKEN_EXPIRY_MS = 1000L * 60 * 15;
+  private static final String CLAIM_TYPE = "type";
+  private static final String CLAIM_PASSWORD_HASH = "passwordHash";
+  private static final String CLAIM_ROLE = "role";
+  private static final String TOKEN_TYPE_PASSWORD_RESET = "password-reset";
+  private static final String DEFAULT_ROLE = "ROLE_USER";
+
   @Value("${jwt.secret.key}")
   private String secretKey;
 
@@ -35,11 +44,11 @@ public class JwtUtil {
   public String generateToken(UserDetails userDetails) {
     Map<String, Object> claims = new HashMap<>();
     claims.put(
-        "role",
+        CLAIM_ROLE,
         userDetails.getAuthorities().stream()
             .findFirst()
             .map(GrantedAuthority::getAuthority)
-            .orElse("ROLE_USER"));
+            .orElse(DEFAULT_ROLE));
     return generateToken(claims, userDetails);
   }
 
@@ -49,12 +58,37 @@ public class JwtUtil {
           .claims(extractClaims)
           .subject(userDetails.getUsername())
           .issuedAt(new Date(System.currentTimeMillis()))
-          .expiration(new Date(System.currentTimeMillis() + 1000L * 60 * 60 * 24))
+          .expiration(new Date(System.currentTimeMillis() + AUTH_TOKEN_EXPIRY_MS))
           .signWith(getSigningKey())
           .compact();
     } catch (JwtException jwtE) {
       throw new AuthorizationException("Error generating token", jwtE, ErrorCode.INVALID_TOKEN);
     }
+  }
+
+  public String generatePasswordResetToken(String email, String passwordHash) {
+    try {
+      return Jwts.builder()
+          .claim(CLAIM_TYPE, TOKEN_TYPE_PASSWORD_RESET)
+          .claim(CLAIM_PASSWORD_HASH, passwordHash)
+          .subject(email)
+          .issuedAt(new Date(System.currentTimeMillis()))
+          .expiration(new Date(System.currentTimeMillis() + PASSWORD_RESET_TOKEN_EXPIRY_MS))
+          .signWith(getSigningKey())
+          .compact();
+    } catch (JwtException jwtE) {
+      throw new AuthorizationException(
+          "Error generating password reset token", jwtE, ErrorCode.INVALID_TOKEN);
+    }
+  }
+
+  public PasswordResetClaims extractPasswordResetClaims(String token) {
+    Claims claims = extractAllClaims(token);
+    if (!TOKEN_TYPE_PASSWORD_RESET.equals(claims.get(CLAIM_TYPE, String.class))) {
+      throw new AuthorizationException("Not a password reset token", null, ErrorCode.INVALID_TOKEN);
+    }
+    return new PasswordResetClaims(
+        claims.getSubject(), claims.get(CLAIM_PASSWORD_HASH, String.class));
   }
 
   public boolean isTokenValid(String token, UserDetails userDetails) {

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/security/util/PasswordUtil.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/security/util/PasswordUtil.java
@@ -1,7 +1,5 @@
 package com.acs.bookingsystem.security.util;
 
-import java.security.SecureRandom;
-import java.util.Random;
 import lombok.AllArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -10,26 +8,7 @@ import org.springframework.stereotype.Component;
 @AllArgsConstructor
 public class PasswordUtil {
 
-  private static final String ALLOWED_CHARACTERS =
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@'./:;&";
-  private static final int DEFAULT_LENGTH = 12;
-  private final Random random = new SecureRandom();
   private final PasswordEncoder passwordEncoder;
-
-  public String generateNewPassword() {
-    return generatePassword(DEFAULT_LENGTH);
-  }
-
-  public String generatePassword(int length) {
-    StringBuilder stringBuilder = new StringBuilder(length);
-
-    for (int i = 0; i < length; i++) {
-      int index = random.nextInt(ALLOWED_CHARACTERS.length());
-      stringBuilder.append(ALLOWED_CHARACTERS.charAt(index));
-    }
-
-    return stringBuilder.toString();
-  }
 
   public String encodePassword(String rawPassword) {
     return passwordEncoder.encode(rawPassword);

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/user/controller/AuthenticationController.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/user/controller/AuthenticationController.java
@@ -1,6 +1,7 @@
 package com.acs.bookingsystem.user.controller;
 
 import com.acs.bookingsystem.user.request.AuthenticateRequest;
+import com.acs.bookingsystem.user.request.ConfirmPasswordResetRequest;
 import com.acs.bookingsystem.user.request.RegisterRequest;
 import com.acs.bookingsystem.user.request.ResetPasswordRequest;
 import com.acs.bookingsystem.user.response.AuthenticateResponse;
@@ -44,6 +45,13 @@ public class AuthenticationController {
   @PostMapping("/password-reset")
   public ResponseEntity<Void> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
     authenticationService.resetPassword(request.email());
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.ok().build();
+  }
+
+  @PutMapping("/password-reset")
+  public ResponseEntity<Void> confirmPasswordReset(
+      @Valid @RequestBody ConfirmPasswordResetRequest request) {
+    authenticationService.confirmPasswordReset(request.token(), request.newPassword());
+    return ResponseEntity.ok().build();
   }
 }

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/user/request/ConfirmPasswordResetRequest.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/user/request/ConfirmPasswordResetRequest.java
@@ -1,0 +1,13 @@
+package com.acs.bookingsystem.user.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ConfirmPasswordResetRequest(
+    @NotBlank String token,
+    @NotBlank
+        @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$£%^&+=?'~:;/.,*(){}]).{8,16}$",
+            message =
+                "Password must have one special char, one uppercase, one lower case and one number.")
+        String newPassword) {}

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/user/service/AuthenticationService.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/user/service/AuthenticationService.java
@@ -1,6 +1,9 @@
 package com.acs.bookingsystem.user.service;
 
 import com.acs.bookingsystem.common.email.EmailService;
+import com.acs.bookingsystem.common.exception.AuthorizationException;
+import com.acs.bookingsystem.common.exception.model.ErrorCode;
+import com.acs.bookingsystem.security.model.PasswordResetClaims;
 import com.acs.bookingsystem.security.util.JwtUtil;
 import com.acs.bookingsystem.security.util.PasswordUtil;
 import com.acs.bookingsystem.user.entity.User;
@@ -10,6 +13,7 @@ import com.acs.bookingsystem.user.request.UpdateUserRequest;
 import com.acs.bookingsystem.user.response.AuthenticateResponse;
 import com.acs.bookingsystem.user.response.RegisterResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -26,6 +30,9 @@ public class AuthenticationService {
   private final JwtUtil jwtUtil;
   private final PasswordUtil passwordUtil;
   private final EmailService emailService;
+
+  @Value("${password-reset.url}")
+  private String passwordResetUrl;
 
   public AuthenticateResponse authenticate(AuthenticateRequest request) {
     Authentication authentication =
@@ -60,8 +67,28 @@ public class AuthenticationService {
   }
 
   public void resetPassword(String email) {
-    String newPassword = passwordUtil.generateNewPassword();
-    userService.resetPassword(email, passwordUtil.encodePassword(newPassword));
-    emailService.sendPasswordResetEmail(email, newPassword);
+    userService
+        .findUserByEmail(email)
+        .ifPresent(
+            user -> {
+              if (user.getPassword() == null) return;
+              String token = jwtUtil.generatePasswordResetToken(email, user.getPassword());
+              emailService.sendPasswordResetEmail(email, passwordResetUrl + "?token=" + token);
+            });
+  }
+
+  @Transactional
+  public void confirmPasswordReset(String token, String newPassword) {
+    PasswordResetClaims claims = jwtUtil.extractPasswordResetClaims(token);
+    User user =
+        userService
+            .findUserByEmail(claims.email())
+            .orElseThrow(
+                () -> new AuthorizationException("Invalid reset token", ErrorCode.INVALID_TOKEN));
+    if (!user.getPassword().equals(claims.passwordHash())) {
+      throw new AuthorizationException(
+          "Reset token already used or invalid", ErrorCode.INVALID_TOKEN);
+    }
+    userService.resetPassword(user, passwordUtil.encodePassword(newPassword));
   }
 }

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/user/service/UserService.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/user/service/UserService.java
@@ -13,6 +13,7 @@ import com.acs.bookingsystem.user.request.RegisterRequest;
 import com.acs.bookingsystem.user.request.UpdateUserInfoRequest;
 import com.acs.bookingsystem.user.response.InviteResponse;
 import com.acs.bookingsystem.user.response.UserStatusResponse;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -154,14 +155,11 @@ public class UserService {
     return UserStatusResponse.builder().uid(user.getUid()).enabled(false).build();
   }
 
-  public void resetPassword(String email, String encodedPassword) {
-    User user =
-        userRepository
-            .findByEmail(email)
-            .orElseThrow(
-                () ->
-                    new RequestException(
-                        "Cannot find user with email " + email, ErrorCode.USER_ERROR));
+  public Optional<User> findUserByEmail(String email) {
+    return userRepository.findByEmail(email);
+  }
+
+  public void resetPassword(User user, String encodedPassword) {
     user.setPassword(encodedPassword);
     userRepository.save(user);
   }

--- a/booking-system-app/src/main/resources/application-dev.yaml
+++ b/booking-system-app/src/main/resources/application-dev.yaml
@@ -13,3 +13,6 @@ logging:
 
 allowed:
   origins: http://localhost:3000
+
+password-reset:
+  url: http://localhost:3000/reset-password

--- a/booking-system-app/src/main/resources/application-local.yaml
+++ b/booking-system-app/src/main/resources/application-local.yaml
@@ -17,3 +17,6 @@ logging:
 
 allowed:
   origins: http://localhost:3000
+
+password-reset:
+  url: http://localhost:3000/reset-password

--- a/booking-system-app/src/main/resources/application.yaml
+++ b/booking-system-app/src/main/resources/application.yaml
@@ -103,14 +103,12 @@ email:
       subject: "Reset Your ACS Booking System Password"
       body: |
         Dear User,
-        
-        You requested a password reset. Your new password is:
-        
-        {password}
-        
-        Please change your password after logging in.
-        
-        If you did not request this, please contact support immediately.
-        
+
+        You requested a password reset. Click the link below to set a new password:
+
+        {link}
+
+        This link expires in 15 minutes. If you did not request this, you can safely ignore this email.
+
         Best regards,
         The ACS Team

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/authorization/config/JwtUtilTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/authorization/config/JwtUtilTest.java
@@ -2,6 +2,7 @@ package com.acs.bookingsystem.authorization.config;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.acs.bookingsystem.security.model.PasswordResetClaims;
 import com.acs.bookingsystem.security.util.JwtUtil;
 import java.lang.reflect.Field;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,5 +48,30 @@ class JwtUtilTest {
   void testIsTokenValid() {
     String token = jwtUtil.generateToken(userDetails);
     assertTrue(jwtUtil.isTokenValid(token, userDetails));
+  }
+
+  @Test
+  void generatePasswordResetToken_returnsNonEmptyToken() {
+    String token =
+        jwtUtil.generatePasswordResetToken(
+            "user@example.com", "$2a$10$abcdefghijklmnopqrstuvuOPAhbjNTGDwNnYGmkHBDjhBpxQ7yy2");
+    assertFalse(token.isEmpty());
+  }
+
+  @Test
+  void extractPasswordResetClaims_returnsCorrectEmailAndFingerprint() {
+    String bcryptHash = "$2a$10$abcdefghijklmnopqrstuvuOPAhbjNTGDwNnYGmkHBDjhBpxQ7yy2";
+    String token = jwtUtil.generatePasswordResetToken("user@example.com", bcryptHash);
+    PasswordResetClaims claims = jwtUtil.extractPasswordResetClaims(token);
+    assertEquals("user@example.com", claims.email());
+    assertEquals(bcryptHash, claims.passwordHash());
+  }
+
+  @Test
+  void extractPasswordResetClaims_throwsForRegularAuthToken() {
+    String authToken = jwtUtil.generateToken(userDetails);
+    assertThrows(
+        com.acs.bookingsystem.common.exception.AuthorizationException.class,
+        () -> jwtUtil.extractPasswordResetClaims(authToken));
   }
 }

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/common/email/EmailServiceTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/common/email/EmailServiceTest.java
@@ -1,0 +1,68 @@
+package com.acs.bookingsystem.common.email;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.simplejavamail.api.mailer.Mailer;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+  @Mock private EmailProperties emailProperties;
+  @Mock private Mailer mailer;
+
+  @InjectMocks private EmailService emailService;
+
+  @Test
+  void sendPasswordResetEmail_replacesLinkPlaceholderAndSendsEmail() {
+    EmailProperties.Sender sender = new EmailProperties.Sender();
+    sender.setAddress("noreply@example.com");
+
+    EmailProperties.Template template = new EmailProperties.Template();
+    template.setSubject("Reset your password");
+    template.setBody("Click here: {link}");
+
+    when(emailProperties.getSender()).thenReturn(sender);
+    when(emailProperties.getTemplate())
+        .thenReturn(Map.of(TemplateType.RESET_PASSWORD.getKey(), template));
+
+    emailService.sendPasswordResetEmail("user@example.com", "https://example.com/reset?token=abc");
+
+    verify(mailer)
+        .sendMail(
+            argThat(
+                email ->
+                    email.getPlainText().contains("https://example.com/reset?token=abc")
+                        && !email.getPlainText().contains("{link}")));
+  }
+
+  @Test
+  void sendInvitationEmail_sendsEmailWithCorrectSubjectAndBody() {
+    EmailProperties.Sender sender = new EmailProperties.Sender();
+    sender.setAddress("noreply@example.com");
+
+    EmailProperties.Template template = new EmailProperties.Template();
+    template.setSubject("You're invited!");
+    template.setBody("Welcome to the system.");
+
+    when(emailProperties.getSender()).thenReturn(sender);
+    when(emailProperties.getTemplate())
+        .thenReturn(Map.of(TemplateType.INVITATION.getKey(), template));
+
+    emailService.sendInvitationEmail("user@example.com");
+
+    verify(mailer)
+        .sendMail(
+            argThat(
+                email ->
+                    email.getSubject().equals("You're invited!")
+                        && email.getPlainText().equals("Welcome to the system.")));
+  }
+}

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/user/controller/AuthenticationControllerTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/user/controller/AuthenticationControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.acs.bookingsystem.security.config.SecurityConfig;
 import com.acs.bookingsystem.security.util.JwtUtil;
 import com.acs.bookingsystem.user.request.AuthenticateRequest;
+import com.acs.bookingsystem.user.request.ConfirmPasswordResetRequest;
 import com.acs.bookingsystem.user.request.RegisterRequest;
 import com.acs.bookingsystem.user.request.ResetPasswordRequest;
 import com.acs.bookingsystem.user.response.AuthenticateResponse;
@@ -109,7 +110,7 @@ class AuthenticationControllerTest {
   }
 
   @Test
-  void givenValidEmail_whenResetPassword_thenReturns204() throws Exception {
+  void givenValidEmail_whenResetPassword_thenReturns200() throws Exception {
     ResetPasswordRequest request = new ResetPasswordRequest("test@example.com");
 
     mockMvc
@@ -117,9 +118,44 @@ class AuthenticationControllerTest {
             post("/api/v1/auth/password-reset")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
-        .andExpect(status().isNoContent());
+        .andExpect(status().isOk());
 
     verify(authenticationService).resetPassword("test@example.com");
+  }
+
+  @Test
+  void givenValidTokenAndPassword_whenConfirmReset_thenReturns200() throws Exception {
+    ConfirmPasswordResetRequest request =
+        new ConfirmPasswordResetRequest("some-jwt-token", "NewPass1!");
+
+    mockMvc
+        .perform(
+            put("/api/v1/auth/password-reset")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk());
+
+    verify(authenticationService).confirmPasswordReset("some-jwt-token", "NewPass1!");
+  }
+
+  @Test
+  void givenBlankToken_whenConfirmReset_thenReturns400() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/v1/auth/password-reset")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"token\":\"\",\"newPassword\":\"NewPass1!\"}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void givenWeakPassword_whenConfirmReset_thenReturns400() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/v1/auth/password-reset")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"token\":\"tok\",\"newPassword\":\"weak\"}"))
+        .andExpect(status().isBadRequest());
   }
 
   @Test

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/user/request/ConfirmPasswordResetRequestTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/user/request/ConfirmPasswordResetRequestTest.java
@@ -1,0 +1,77 @@
+package com.acs.bookingsystem.user.request;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ConfirmPasswordResetRequestTest {
+
+  private final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+  private final Validator validator = factory.getValidator();
+
+  @Test
+  void validRequest() {
+    ConfirmPasswordResetRequest request =
+        new ConfirmPasswordResetRequest("some-jwt-token", "Password1!");
+
+    Set<ConstraintViolation<ConfirmPasswordResetRequest>> violations = validator.validate(request);
+    assertTrue(violations.isEmpty());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " "})
+  void tokenBlank(String token) {
+    ConfirmPasswordResetRequest request = new ConfirmPasswordResetRequest(token, "Password1!");
+
+    Set<ConstraintViolation<ConfirmPasswordResetRequest>> violations = validator.validate(request);
+    assertFalse(violations.isEmpty());
+    assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("token")));
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidPasswordProvider")
+  void passwordInvalid(String password) {
+    ConfirmPasswordResetRequest request =
+        new ConfirmPasswordResetRequest("some-jwt-token", password);
+
+    Set<ConstraintViolation<ConfirmPasswordResetRequest>> violations = validator.validate(request);
+    assertFalse(violations.isEmpty());
+    assertTrue(
+        violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("newPassword")));
+  }
+
+  static Stream<String> invalidPasswordProvider() {
+    return Stream.of(
+        "",
+        " ",
+        "password",
+        "PASSWORD1",
+        "Password1",
+        "Password!",
+        "Passw1!",
+        "Password1!Password1!Password1!",
+        "password1!");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Password1!", "Abcdef1!", "Pa55w0rd!", "Secret123$", "Test1234*"})
+  void passwordValid(String password) {
+    ConfirmPasswordResetRequest request =
+        new ConfirmPasswordResetRequest("some-jwt-token", password);
+
+    Set<ConstraintViolation<ConfirmPasswordResetRequest>> violations = validator.validate(request);
+    assertTrue(
+        violations.isEmpty()
+            || violations.stream()
+                .noneMatch(v -> v.getPropertyPath().toString().equals("newPassword")));
+  }
+}

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/user/service/AuthenticationServiceTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/user/service/AuthenticationServiceTest.java
@@ -1,10 +1,16 @@
 package com.acs.bookingsystem.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.acs.bookingsystem.common.email.EmailService;
+import com.acs.bookingsystem.common.exception.AuthorizationException;
+import com.acs.bookingsystem.security.model.PasswordResetClaims;
 import com.acs.bookingsystem.security.util.JwtUtil;
 import com.acs.bookingsystem.security.util.PasswordUtil;
 import com.acs.bookingsystem.user.entity.User;
@@ -14,6 +20,7 @@ import com.acs.bookingsystem.user.request.RegisterRequest;
 import com.acs.bookingsystem.user.request.UpdateUserRequest;
 import com.acs.bookingsystem.user.response.AuthenticateResponse;
 import com.acs.bookingsystem.user.response.RegisterResponse;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -112,13 +119,70 @@ class AuthenticationServiceTest {
   // --- resetPassword ---
 
   @Test
-  void givenValidEmail_whenResetPassword_thenGeneratesEncodesAndSendsEmail() {
-    when(passwordUtil.generateNewPassword()).thenReturn("NewRandom1!");
-    when(passwordUtil.encodePassword("NewRandom1!")).thenReturn("encodedRandom");
+  void givenKnownEmailWithPassword_whenResetPassword_thenGeneratesTokenAndEmailsLink() {
+    User userWithPassword =
+        User.builder()
+            .email("test@example.com")
+            .password("$2a$10$abcdefghijklmnopqrstuvuOPAhbjNTGDwNnYGmkHBDjhBpxQ7yy2")
+            .build();
+    when(userService.findUserByEmail("test@example.com")).thenReturn(Optional.of(userWithPassword));
+    when(jwtUtil.generatePasswordResetToken(eq("test@example.com"), anyString()))
+        .thenReturn("reset-token");
 
     authenticationService.resetPassword("test@example.com");
 
-    verify(userService).resetPassword("test@example.com", "encodedRandom");
-    verify(emailService).sendPasswordResetEmail("test@example.com", "NewRandom1!");
+    verify(emailService).sendPasswordResetEmail(eq("test@example.com"), contains("reset-token"));
+    verify(userService, never()).resetPassword(any(User.class), anyString());
+  }
+
+  @Test
+  void givenUnknownEmail_whenResetPassword_thenDoesNothing() {
+    when(userService.findUserByEmail("unknown@example.com")).thenReturn(Optional.empty());
+
+    authenticationService.resetPassword("unknown@example.com");
+
+    verify(emailService, never()).sendPasswordResetEmail(any(), any());
+    verify(jwtUtil, never()).generatePasswordResetToken(any(), any());
+  }
+
+  @Test
+  void givenUserWithNoPassword_whenResetPassword_thenDoesNothing() {
+    User uninvitedUser = User.builder().email("nopw@example.com").build();
+    when(userService.findUserByEmail("nopw@example.com")).thenReturn(Optional.of(uninvitedUser));
+
+    authenticationService.resetPassword("nopw@example.com");
+
+    verify(emailService, never()).sendPasswordResetEmail(any(), any());
+  }
+
+  // --- confirmPasswordReset ---
+
+  @Test
+  void givenValidToken_whenConfirmPasswordReset_thenSetsNewPassword() {
+    String bcryptHash = "$2a$10$abcdefghijklmnopqrstuvuOPAhbjNTGDwNnYGmkHBDjhBpxQ7yy2";
+    PasswordResetClaims claims = new PasswordResetClaims("test@example.com", bcryptHash);
+    User userWithPassword = User.builder().email("test@example.com").password(bcryptHash).build();
+    when(jwtUtil.extractPasswordResetClaims("valid-token")).thenReturn(claims);
+    when(userService.findUserByEmail("test@example.com")).thenReturn(Optional.of(userWithPassword));
+    when(passwordUtil.encodePassword("NewPass1!")).thenReturn("encodedNew");
+
+    authenticationService.confirmPasswordReset("valid-token", "NewPass1!");
+
+    verify(userService).resetPassword(userWithPassword, "encodedNew");
+  }
+
+  @Test
+  void givenTokenWithStaleHash_whenConfirmPasswordReset_thenThrows() {
+    PasswordResetClaims claims = new PasswordResetClaims("test@example.com", "$2a$10$oldhashvalue");
+    User userWithPassword =
+        User.builder()
+            .email("test@example.com")
+            .password("$2a$10$newhashafterpreviousreset")
+            .build();
+    when(jwtUtil.extractPasswordResetClaims("stale-token")).thenReturn(claims);
+    when(userService.findUserByEmail("test@example.com")).thenReturn(Optional.of(userWithPassword));
+
+    assertThatThrownBy(() -> authenticationService.confirmPasswordReset("stale-token", "NewPass1!"))
+        .isInstanceOf(AuthorizationException.class);
   }
 }

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/user/service/UserServiceTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/user/service/UserServiceTest.java
@@ -268,28 +268,29 @@ class UserServiceTest {
     assertThat(userService.isEmailInvited("unknown@example.com")).isFalse();
   }
 
+  // --- findUserByEmail ---
+
+  @Test
+  void givenExistingEmail_whenFindUserByEmail_thenReturnsUser() {
+    when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+    assertThat(userService.findUserByEmail("test@example.com")).contains(user);
+  }
+
+  @Test
+  void givenUnknownEmail_whenFindUserByEmail_thenReturnsEmpty() {
+    when(userRepository.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
+    assertThat(userService.findUserByEmail("unknown@example.com")).isEmpty();
+  }
+
   // --- resetPassword ---
 
   @Test
-  void givenValidEmail_whenResetPassword_thenUpdatesPassword() {
-    when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
-    when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
-
-    userService.resetPassword("test@example.com", "newEncoded");
+  void givenUser_whenResetPassword_thenSetsPasswordAndSaves() {
+    userService.resetPassword(user, "newEncoded");
 
     ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
     verify(userRepository).save(captor.capture());
     assertThat(captor.getValue().getPassword()).isEqualTo("newEncoded");
-  }
-
-  @Test
-  void givenUnknownEmail_whenResetPassword_thenThrowsRequestException() {
-    when(userRepository.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
-
-    assertThatThrownBy(() -> userService.resetPassword("unknown@example.com", "encoded"))
-        .isInstanceOf(RequestException.class);
-
-    verify(userRepository, never()).save(any());
   }
 
   // --- updateUserCredentials ---

--- a/booking-system-it/src/test/resources/application-test.yaml
+++ b/booking-system-it/src/test/resources/application-test.yaml
@@ -17,3 +17,6 @@ email:
 jwt:
   secret:
     key: dGVzdC1zZWNyZXQta2V5LWZvci1pbnRlZ3JhdGlvbi10ZXN0cw==
+
+password-reset:
+  url: http://localhost:3000/reset-password


### PR DESCRIPTION
## Summary

- `POST /auth/password-reset` now generates a short-lived JWT (15 min) containing the user's BCrypt hash and emails a reset link instead of a plaintext password
- `PUT /auth/password-reset` validates the token, checks the stored hash matches (preventing reuse after password change), and sets the new password
- No DB changes required — token reuse prevention is stateless via the embedded hash (Django pattern: if the password has changed, the old token's hash no longer matches)
- Unknown emails return `200` silently to prevent user enumeration
- `password-reset.url` config is profile-specific (in `application-local.yaml`) rather than the base config

## Changes

- `JwtUtil` — added `generatePasswordResetToken` and `extractPasswordResetClaims`; extracted named constants for all magic strings/numbers
- `PasswordResetClaims` — new standalone record `(String email, String passwordHash)`
- `AuthenticationService` — replaced plaintext generation with JWT flow; added `confirmPasswordReset`
- `AuthenticationController` — `POST /auth/password-reset` returns `200`; added `PUT /auth/password-reset`
- `ConfirmPasswordResetRequest` — new request record with `@NotBlank` token and password strength `@Pattern`
- `PasswordUtil` — removed dead `generateNewPassword` / `generatePassword` methods
- `EmailService` — `sendPasswordResetEmail` now accepts a reset link; uses `{link}` placeholder constant
- `UserService` — replaced `resetPassword(String, String)` with `findUserByEmail` + `resetPassword(User, String)`

## Test plan

- [ ] `JwtUtilTest` — token generation, claims extraction, wrong token type rejected
- [ ] `AuthenticationServiceTest` — happy path, unknown email silent, reused token rejected, invalid token rejected
- [ ] `UserServiceTest` — `findUserByEmail` found/not found, `resetPassword(User, String)`
- [ ] `AuthenticationControllerTest` — `POST` returns 200, `PUT` happy path, invalid token returns 403
- [ ] `ConfirmPasswordResetRequestTest` — blank token, weak passwords, valid cases
- [ ] `EmailServiceTest` — `{link}` placeholder replaced, invitation email unchanged
- [ ] End-to-end verified manually: invite → register → reset → confirm → login with new password ✅