### PR TITLE
BOO-8: Add rate limiting to auth endpoints

### DIFF
--- a/booking-system-app/pom.xml
+++ b/booking-system-app/pom.xml
@@ -30,6 +30,25 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j-core</artifactId>
+            <version>8.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j-caffeine</artifactId>
+            <version>8.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.2.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/common/exception/handler/UniversalExceptionHandler.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/common/exception/handler/UniversalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.acs.bookingsystem.common.exception.RequestException;
 import com.acs.bookingsystem.common.exception.model.ErrorCode;
 import com.acs.bookingsystem.common.exception.model.ErrorDetail;
 import com.acs.bookingsystem.common.exception.model.ErrorModel;
+import com.acs.bookingsystem.common.ratelimit.RateLimitExceededException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import jakarta.validation.ConstraintViolationException;
 import java.util.Arrays;
@@ -14,6 +15,7 @@ import java.util.Date;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -170,6 +172,21 @@ public class UniversalExceptionHandler {
             determineAuthenticationMessage(ex),
             List.of());
     return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
+  }
+
+  @ExceptionHandler(RateLimitExceededException.class)
+  public ResponseEntity<ErrorModel> handleRateLimitExceeded(RateLimitExceededException ex) {
+    LOG.warn("Rate limit exceeded: {}", ex.getMessage());
+    ErrorModel error =
+        new ErrorModel(
+            new Date(),
+            HttpStatus.TOO_MANY_REQUESTS.value(),
+            ErrorCode.RATE_LIMIT_EXCEEDED.toString(),
+            ErrorCode.RATE_LIMIT_EXCEEDED.getDescription(),
+            List.of());
+    return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+        .header(HttpHeaders.RETRY_AFTER, String.valueOf(ex.getRetryAfterSeconds()))
+        .body(error);
   }
 
   private static String getFormatErrorMessage(Throwable cause) {

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/common/exception/model/ErrorCode.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/common/exception/model/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
   BOOKING_CONFLICT("Booking timeslot is unavailable."),
   BOOKING_SHAREABLE_LIMIT("Booking shareable limit reached."),
   BOOKING_LOCK_TIMEOUT("Booking could not be processed due to high demand. Please try again."),
-  CONFLICT("Request conflict. Please try again.");
+  CONFLICT("Request conflict. Please try again."),
+  RATE_LIMIT_EXCEEDED("Too many requests. Please try again later.");
 
   private final String description;
 }

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/ClientIpResolver.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/ClientIpResolver.java
@@ -1,0 +1,12 @@
+package com.acs.bookingsystem.common.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ClientIpResolver {
+
+  public String resolve(HttpServletRequest request) {
+    return request.getRemoteAddr();
+  }
+}

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimit.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimit.java
@@ -1,0 +1,17 @@
+package com.acs.bookingsystem.common.ratelimit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimit {
+
+  String bucket();
+
+  RateLimitKeyType key();
+
+  String keyExpression() default "";
+}

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimitAspect.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimitAspect.java
@@ -27,10 +27,16 @@ public class RateLimitAspect {
       new DefaultParameterNameDiscoverer();
   private final ExpressionParser expressionParser = new SpelExpressionParser();
 
-  @Around("@annotation(rateLimit)")
-  public Object enforceLimit(ProceedingJoinPoint joinPoint, RateLimit rateLimit) throws Throwable {
-    String key = resolveKey(joinPoint, rateLimit);
-    rateLimiter.checkLimit(rateLimit.bucket(), key);
+  @Around(
+      "@annotation(com.acs.bookingsystem.common.ratelimit.RateLimit) || "
+          + "@annotation(com.acs.bookingsystem.common.ratelimit.RateLimits)")
+  public Object enforceLimit(ProceedingJoinPoint joinPoint) throws Throwable {
+    MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+    RateLimit[] rateLimits = signature.getMethod().getAnnotationsByType(RateLimit.class);
+    for (RateLimit rateLimit : rateLimits) {
+      String key = resolveKey(joinPoint, rateLimit);
+      rateLimiter.checkLimit(rateLimit.bucket(), key);
+    }
     return joinPoint.proceed();
   }
 
@@ -48,6 +54,8 @@ public class RateLimitAspect {
     return clientIpResolver.resolve(request);
   }
 
+  // Relies on parameter name debug info being compiled in (javac -g, on by default via
+  // spring-boot-starter-parent) so #paramName resolves to the real argument name below.
   private String resolveSpel(ProceedingJoinPoint joinPoint, String expression) {
     MethodSignature signature = (MethodSignature) joinPoint.getSignature();
     String[] paramNames = parameterNameDiscoverer.getParameterNames(signature.getMethod());

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimitAspect.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimitAspect.java
@@ -1,0 +1,62 @@
+package com.acs.bookingsystem.common.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.core.ParameterNameDiscoverer;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class RateLimitAspect {
+
+  private final RateLimiter rateLimiter;
+  private final ClientIpResolver clientIpResolver;
+  private final ParameterNameDiscoverer parameterNameDiscoverer =
+      new DefaultParameterNameDiscoverer();
+  private final ExpressionParser expressionParser = new SpelExpressionParser();
+
+  @Around("@annotation(rateLimit)")
+  public Object enforceLimit(ProceedingJoinPoint joinPoint, RateLimit rateLimit) throws Throwable {
+    String key = resolveKey(joinPoint, rateLimit);
+    rateLimiter.checkLimit(rateLimit.bucket(), key);
+    return joinPoint.proceed();
+  }
+
+  private String resolveKey(ProceedingJoinPoint joinPoint, RateLimit rateLimit) {
+    return switch (rateLimit.key()) {
+      case IP -> resolveIp();
+      case SPEL -> resolveSpel(joinPoint, rateLimit.keyExpression());
+    };
+  }
+
+  private String resolveIp() {
+    ServletRequestAttributes attributes =
+        (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+    HttpServletRequest request = attributes.getRequest();
+    return clientIpResolver.resolve(request);
+  }
+
+  private String resolveSpel(ProceedingJoinPoint joinPoint, String expression) {
+    MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+    String[] paramNames = parameterNameDiscoverer.getParameterNames(signature.getMethod());
+    Object[] args = joinPoint.getArgs();
+
+    EvaluationContext context = new StandardEvaluationContext();
+    for (int i = 0; i < paramNames.length; i++) {
+      context.setVariable(paramNames[i], args[i]);
+    }
+    return expressionParser.parseExpression(expression).getValue(context, String.class);
+  }
+}

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimitConfig.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimitConfig.java
@@ -1,0 +1,21 @@
+package com.acs.bookingsystem.common.ratelimit;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.github.bucket4j.caffeine.CaffeineProxyManager;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import java.time.Duration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RateLimitConfig {
+
+  private static final int MAX_CACHE_ENTRIES = 100_000;
+  private static final Duration CACHE_EXPIRY = Duration.ofHours(2);
+
+  @Bean
+  public ProxyManager<String> rateLimitProxyManager() {
+    Caffeine<Object, Object> caffeine = Caffeine.newBuilder().maximumSize(MAX_CACHE_ENTRIES);
+    return new CaffeineProxyManager<>(caffeine, CACHE_EXPIRY);
+  }
+}

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimitExceededException.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimitExceededException.java
@@ -1,0 +1,14 @@
+package com.acs.bookingsystem.common.ratelimit;
+
+import lombok.Getter;
+
+@Getter
+public class RateLimitExceededException extends RuntimeException {
+
+  private final long retryAfterSeconds;
+
+  public RateLimitExceededException(long retryAfterSeconds) {
+    super("Rate limit exceeded. Retry after " + retryAfterSeconds + " seconds.");
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimitKeyType.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimitKeyType.java
@@ -1,0 +1,6 @@
+package com.acs.bookingsystem.common.ratelimit;
+
+public enum RateLimitKeyType {
+  IP,
+  SPEL
+}

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimitProperties.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimitProperties.java
@@ -1,0 +1,24 @@
+package com.acs.bookingsystem.common.ratelimit;
+
+import java.time.Duration;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "rate-limit")
+public class RateLimitProperties {
+
+  private Map<String, Bucket> buckets;
+
+  @Getter
+  @Setter
+  public static class Bucket {
+    private long capacity;
+    private Duration refillPeriod;
+  }
+}

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimiter.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimiter.java
@@ -17,6 +17,10 @@ public class RateLimiter {
 
   public void checkLimit(String bucketName, String key) {
     RateLimitProperties.Bucket config = properties.getBuckets().get(bucketName);
+    if (config == null) {
+      throw new IllegalArgumentException(
+          "No rate limit configuration found for bucket: " + bucketName);
+    }
     BucketProxy bucket =
         proxyManager.builder().build(bucketName + ":" + key, () -> buildConfiguration(config));
 

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimiter.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimiter.java
@@ -1,0 +1,39 @@
+package com.acs.bookingsystem.common.ratelimit;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.ConsumptionProbe;
+import io.github.bucket4j.distributed.BucketProxy;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RateLimiter {
+
+  private final RateLimitProperties properties;
+  private final ProxyManager<String> proxyManager;
+
+  public void checkLimit(String bucketName, String key) {
+    RateLimitProperties.Bucket config = properties.getBuckets().get(bucketName);
+    BucketProxy bucket =
+        proxyManager.builder().build(bucketName + ":" + key, () -> buildConfiguration(config));
+
+    ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
+    if (!probe.isConsumed()) {
+      long retryAfterSeconds =
+          Math.max(1, (long) Math.ceil(probe.getNanosToWaitForRefill() / 1_000_000_000.0));
+      throw new RateLimitExceededException(retryAfterSeconds);
+    }
+  }
+
+  private BucketConfiguration buildConfiguration(RateLimitProperties.Bucket config) {
+    Bandwidth limit =
+        Bandwidth.builder()
+            .capacity(config.getCapacity())
+            .refillGreedy(config.getCapacity(), config.getRefillPeriod())
+            .build();
+    return BucketConfiguration.builder().addLimit(limit).build();
+  }
+}

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimits.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/common/ratelimit/RateLimits.java
@@ -1,19 +1,13 @@
 package com.acs.bookingsystem.common.ratelimit;
 
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@Repeatable(RateLimits.class)
-public @interface RateLimit {
+public @interface RateLimits {
 
-  String bucket();
-
-  RateLimitKeyType key();
-
-  String keyExpression() default "";
+  RateLimit[] value();
 }

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/user/controller/AuthenticationController.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/user/controller/AuthenticationController.java
@@ -1,5 +1,7 @@
 package com.acs.bookingsystem.user.controller;
 
+import com.acs.bookingsystem.common.ratelimit.RateLimit;
+import com.acs.bookingsystem.common.ratelimit.RateLimitKeyType;
 import com.acs.bookingsystem.user.request.AuthenticateRequest;
 import com.acs.bookingsystem.user.request.ConfirmPasswordResetRequest;
 import com.acs.bookingsystem.user.request.RegisterRequest;
@@ -27,22 +29,29 @@ public class AuthenticationController {
   private final UserService userService;
 
   @PostMapping("/register")
+  @RateLimit(bucket = "register", key = RateLimitKeyType.IP)
   public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
     return ResponseEntity.status(HttpStatus.CREATED).body(authenticationService.register(request));
   }
 
   @PostMapping("/login")
+  @RateLimit(bucket = "login", key = RateLimitKeyType.IP)
   public ResponseEntity<AuthenticateResponse> authenticate(
       @Valid @RequestBody AuthenticateRequest request) {
     return ResponseEntity.ok(authenticationService.authenticate(request));
   }
 
   @GetMapping("/invitations")
+  @RateLimit(bucket = "checkInvite", key = RateLimitKeyType.IP)
   public ResponseEntity<CheckInviteResponse> checkInvite(@RequestParam @Email String email) {
     return ResponseEntity.ok(new CheckInviteResponse(email, userService.isEmailInvited(email)));
   }
 
   @PostMapping("/password-reset")
+  @RateLimit(
+      bucket = "passwordReset",
+      key = RateLimitKeyType.SPEL,
+      keyExpression = "#request.email()")
   public ResponseEntity<Void> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
     authenticationService.resetPassword(request.email());
     return ResponseEntity.ok().build();

--- a/booking-system-app/src/main/java/com/acs/bookingsystem/user/controller/AuthenticationController.java
+++ b/booking-system-app/src/main/java/com/acs/bookingsystem/user/controller/AuthenticationController.java
@@ -52,6 +52,7 @@ public class AuthenticationController {
       bucket = "passwordReset",
       key = RateLimitKeyType.SPEL,
       keyExpression = "#request.email()")
+  @RateLimit(bucket = "passwordResetIp", key = RateLimitKeyType.IP)
   public ResponseEntity<Void> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
     authenticationService.resetPassword(request.email());
     return ResponseEntity.ok().build();

--- a/booking-system-app/src/main/resources/application-dev.yaml
+++ b/booking-system-app/src/main/resources/application-dev.yaml
@@ -4,9 +4,6 @@ spring:
       username: ${POSTGRES_USER}
       password: ${POSTGRES_PASSWORD}
 
-  flyway:
-    enabled: true
-
 logging:
   level:
     org.flywaydb: INFO

--- a/booking-system-app/src/main/resources/application.yaml
+++ b/booking-system-app/src/main/resources/application.yaml
@@ -110,3 +110,18 @@ email:
 
         Best regards,
         The ACS Team
+
+rate-limit:
+  buckets:
+    login:
+      capacity: 10
+      refill-period: 1m
+    passwordReset:
+      capacity: 3
+      refill-period: 15m
+    register:
+      capacity: 10
+      refill-period: 1h
+    checkInvite:
+      capacity: 20
+      refill-period: 1m

--- a/booking-system-app/src/main/resources/application.yaml
+++ b/booking-system-app/src/main/resources/application.yaml
@@ -119,6 +119,9 @@ rate-limit:
     passwordReset:
       capacity: 3
       refill-period: 15m
+    passwordResetIp:
+      capacity: 10
+      refill-period: 1h
     register:
       capacity: 10
       refill-period: 1h

--- a/booking-system-app/src/main/resources/application.yaml
+++ b/booking-system-app/src/main/resources/application.yaml
@@ -25,11 +25,9 @@ spring:
 
   datasource:
     hikari: # HikariCP is your connection pool
-      maximum-pool-size: 3      # Max 3 database connections (down from default 10)
-      minimum-idle: 1           # Keep at least 1 connection open (down from default 5)
+      minimum-idle: 0           # Let the pool drain to zero so Neon can auto-suspend when idle
       idle-timeout: 300000      # Close idle connections after 5 minutes
       max-lifetime: 1200000     # Replace connections every 20 minutes
-      connection-timeout: 20000 # Wait 20 seconds for connection before failing
       leak-detection-threshold: 60000  # Warn if connection held longer than 1 minute
       auto-commit: false        # HikariCP disables auto-commit
 

--- a/booking-system-app/src/main/resources/application.yaml
+++ b/booking-system-app/src/main/resources/application.yaml
@@ -34,7 +34,7 @@ spring:
       auto-commit: false        # HikariCP disables auto-commit
 
   flyway:
-    enabled: false
+    enabled: true
 
 logging:
   level:

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/common/exception/handler/UniversalExceptionHandlerTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/common/exception/handler/UniversalExceptionHandlerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -12,6 +13,7 @@ import com.acs.bookingsystem.common.exception.LockTimeoutException;
 import com.acs.bookingsystem.common.exception.NotFoundException;
 import com.acs.bookingsystem.common.exception.RequestException;
 import com.acs.bookingsystem.common.exception.model.ErrorCode;
+import com.acs.bookingsystem.common.ratelimit.RateLimitExceededException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -111,6 +113,11 @@ class UniversalExceptionHandlerTest {
     @GetMapping("/test/missing-param")
     void requireParam(@RequestParam boolean enable) {
       // intentionally empty — exists only to trigger MissingServletRequestParameterException
+    }
+
+    @GetMapping("/test/rate-limit")
+    void throwRateLimitExceededException() {
+      throw new RateLimitExceededException(5);
     }
   }
 
@@ -240,5 +247,15 @@ class UniversalExceptionHandlerTest {
         .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"))
         .andExpect(jsonPath("$.details[0].field").value("enable"))
         .andExpect(jsonPath("$.details[0].message").value("Required parameter is missing"));
+  }
+
+  @Test
+  void givenRateLimitExceededException_shouldReturn429WithRetryAfterHeader() throws Exception {
+    mockMvc
+        .perform(get("/test/rate-limit"))
+        .andExpect(status().isTooManyRequests())
+        .andExpect(header().string("Retry-After", "5"))
+        .andExpect(jsonPath("$.status").value(429))
+        .andExpect(jsonPath("$.error").value("RATE_LIMIT_EXCEEDED"));
   }
 }

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/common/ratelimit/ClientIpResolverTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/common/ratelimit/ClientIpResolverTest.java
@@ -1,0 +1,32 @@
+package com.acs.bookingsystem.common.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class ClientIpResolverTest {
+
+  private final ClientIpResolver resolver = new ClientIpResolver();
+
+  @Test
+  void resolvesRemoteAddrFromRequest() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRemoteAddr("203.0.113.42");
+
+    String result = resolver.resolve(request);
+
+    assertThat(result).isEqualTo("203.0.113.42");
+  }
+
+  @Test
+  void ignoresXForwardedForHeader() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRemoteAddr("203.0.113.42");
+    request.addHeader("X-Forwarded-For", "1.2.3.4");
+
+    String result = resolver.resolve(request);
+
+    assertThat(result).isEqualTo("203.0.113.42");
+  }
+}

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/common/ratelimit/RateLimitAspectTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/common/ratelimit/RateLimitAspectTest.java
@@ -1,0 +1,108 @@
+package com.acs.bookingsystem.common.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.Method;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+class RateLimitAspectTest {
+
+  @Mock private RateLimiter rateLimiter;
+  @Mock private ClientIpResolver clientIpResolver;
+  @Mock private ProceedingJoinPoint joinPoint;
+  @Mock private MethodSignature methodSignature;
+
+  private RateLimitAspect aspect;
+
+  static class Dummy {
+    @RateLimit(bucket = "login", key = RateLimitKeyType.IP)
+    void ipLimited() {}
+
+    @RateLimit(
+        bucket = "passwordReset",
+        key = RateLimitKeyType.SPEL,
+        keyExpression = "#request.email()")
+    void spelLimited(DummyRequest request) {}
+  }
+
+  record DummyRequest(String email) {}
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    aspect = new RateLimitAspect(rateLimiter, clientIpResolver);
+  }
+
+  @AfterEach
+  void tearDown() {
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  @Test
+  void resolvesIpKeyAndProceedsWhenWithinLimit() throws Throwable {
+    Method method = Dummy.class.getDeclaredMethod("ipLimited");
+    RateLimit rateLimit = method.getAnnotation(RateLimit.class);
+    when(joinPoint.getSignature()).thenReturn(methodSignature);
+    when(methodSignature.getMethod()).thenReturn(method);
+    when(joinPoint.getArgs()).thenReturn(new Object[0]);
+    when(joinPoint.proceed()).thenReturn("ok");
+
+    MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(servletRequest));
+    when(clientIpResolver.resolve(any(HttpServletRequest.class))).thenReturn("1.2.3.4");
+
+    Object result = aspect.enforceLimit(joinPoint, rateLimit);
+
+    assertThat(result).isEqualTo("ok");
+    verify(rateLimiter).checkLimit("login", "1.2.3.4");
+    verify(joinPoint).proceed();
+  }
+
+  @Test
+  void resolvesSpelKeyFromMethodArgument() throws Throwable {
+    Method method = Dummy.class.getDeclaredMethod("spelLimited", DummyRequest.class);
+    RateLimit rateLimit = method.getAnnotation(RateLimit.class);
+    DummyRequest request = new DummyRequest("user@example.com");
+    when(joinPoint.getSignature()).thenReturn(methodSignature);
+    when(methodSignature.getMethod()).thenReturn(method);
+    when(joinPoint.getArgs()).thenReturn(new Object[] {request});
+    when(joinPoint.proceed()).thenReturn("ok");
+
+    aspect.enforceLimit(joinPoint, rateLimit);
+
+    verify(rateLimiter).checkLimit("passwordReset", "user@example.com");
+  }
+
+  @Test
+  void propagatesRateLimitExceededExceptionWithoutProceeding() throws Throwable {
+    Method method = Dummy.class.getDeclaredMethod("ipLimited");
+    RateLimit rateLimit = method.getAnnotation(RateLimit.class);
+    when(joinPoint.getSignature()).thenReturn(methodSignature);
+    when(methodSignature.getMethod()).thenReturn(method);
+    when(joinPoint.getArgs()).thenReturn(new Object[0]);
+
+    MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(servletRequest));
+    when(clientIpResolver.resolve(any(HttpServletRequest.class))).thenReturn("1.2.3.4");
+    doThrow(new RateLimitExceededException(5)).when(rateLimiter).checkLimit("login", "1.2.3.4");
+
+    assertThrows(RateLimitExceededException.class, () -> aspect.enforceLimit(joinPoint, rateLimit));
+    verify(joinPoint, never()).proceed();
+  }
+}

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/common/ratelimit/RateLimitAspectTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/common/ratelimit/RateLimitAspectTest.java
@@ -39,6 +39,13 @@ class RateLimitAspectTest {
         key = RateLimitKeyType.SPEL,
         keyExpression = "#request.email()")
     void spelLimited(DummyRequest request) {}
+
+    @RateLimit(
+        bucket = "passwordReset",
+        key = RateLimitKeyType.SPEL,
+        keyExpression = "#request.email()")
+    @RateLimit(bucket = "passwordResetIp", key = RateLimitKeyType.IP)
+    void stackedLimited(DummyRequest request) {}
   }
 
   record DummyRequest(String email) {}
@@ -57,7 +64,6 @@ class RateLimitAspectTest {
   @Test
   void resolvesIpKeyAndProceedsWhenWithinLimit() throws Throwable {
     Method method = Dummy.class.getDeclaredMethod("ipLimited");
-    RateLimit rateLimit = method.getAnnotation(RateLimit.class);
     when(joinPoint.getSignature()).thenReturn(methodSignature);
     when(methodSignature.getMethod()).thenReturn(method);
     when(joinPoint.getArgs()).thenReturn(new Object[0]);
@@ -67,7 +73,7 @@ class RateLimitAspectTest {
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(servletRequest));
     when(clientIpResolver.resolve(any(HttpServletRequest.class))).thenReturn("1.2.3.4");
 
-    Object result = aspect.enforceLimit(joinPoint, rateLimit);
+    Object result = aspect.enforceLimit(joinPoint);
 
     assertThat(result).isEqualTo("ok");
     verify(rateLimiter).checkLimit("login", "1.2.3.4");
@@ -77,14 +83,13 @@ class RateLimitAspectTest {
   @Test
   void resolvesSpelKeyFromMethodArgument() throws Throwable {
     Method method = Dummy.class.getDeclaredMethod("spelLimited", DummyRequest.class);
-    RateLimit rateLimit = method.getAnnotation(RateLimit.class);
     DummyRequest request = new DummyRequest("user@example.com");
     when(joinPoint.getSignature()).thenReturn(methodSignature);
     when(methodSignature.getMethod()).thenReturn(method);
     when(joinPoint.getArgs()).thenReturn(new Object[] {request});
     when(joinPoint.proceed()).thenReturn("ok");
 
-    aspect.enforceLimit(joinPoint, rateLimit);
+    aspect.enforceLimit(joinPoint);
 
     verify(rateLimiter).checkLimit("passwordReset", "user@example.com");
   }
@@ -92,7 +97,6 @@ class RateLimitAspectTest {
   @Test
   void propagatesRateLimitExceededExceptionWithoutProceeding() throws Throwable {
     Method method = Dummy.class.getDeclaredMethod("ipLimited");
-    RateLimit rateLimit = method.getAnnotation(RateLimit.class);
     when(joinPoint.getSignature()).thenReturn(methodSignature);
     when(methodSignature.getMethod()).thenReturn(method);
     when(joinPoint.getArgs()).thenReturn(new Object[0]);
@@ -102,7 +106,45 @@ class RateLimitAspectTest {
     when(clientIpResolver.resolve(any(HttpServletRequest.class))).thenReturn("1.2.3.4");
     doThrow(new RateLimitExceededException(5)).when(rateLimiter).checkLimit("login", "1.2.3.4");
 
-    assertThrows(RateLimitExceededException.class, () -> aspect.enforceLimit(joinPoint, rateLimit));
+    assertThrows(RateLimitExceededException.class, () -> aspect.enforceLimit(joinPoint));
+    verify(joinPoint, never()).proceed();
+  }
+
+  @Test
+  void checksEveryStackedRateLimitAndProceedsWhenAllWithinLimit() throws Throwable {
+    Method method = Dummy.class.getDeclaredMethod("stackedLimited", DummyRequest.class);
+    DummyRequest request = new DummyRequest("user@example.com");
+    when(joinPoint.getSignature()).thenReturn(methodSignature);
+    when(methodSignature.getMethod()).thenReturn(method);
+    when(joinPoint.getArgs()).thenReturn(new Object[] {request});
+    when(joinPoint.proceed()).thenReturn("ok");
+
+    MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(servletRequest));
+    when(clientIpResolver.resolve(any(HttpServletRequest.class))).thenReturn("1.2.3.4");
+
+    Object result = aspect.enforceLimit(joinPoint);
+
+    assertThat(result).isEqualTo("ok");
+    verify(rateLimiter).checkLimit("passwordReset", "user@example.com");
+    verify(rateLimiter).checkLimit("passwordResetIp", "1.2.3.4");
+    verify(joinPoint).proceed();
+  }
+
+  @Test
+  void stackedRateLimitStopsAtFirstBreachWithoutCheckingTheRest() throws Throwable {
+    Method method = Dummy.class.getDeclaredMethod("stackedLimited", DummyRequest.class);
+    DummyRequest request = new DummyRequest("user@example.com");
+    when(joinPoint.getSignature()).thenReturn(methodSignature);
+    when(methodSignature.getMethod()).thenReturn(method);
+    when(joinPoint.getArgs()).thenReturn(new Object[] {request});
+    doThrow(new RateLimitExceededException(5))
+        .when(rateLimiter)
+        .checkLimit("passwordReset", "user@example.com");
+
+    assertThrows(RateLimitExceededException.class, () -> aspect.enforceLimit(joinPoint));
+
+    verify(rateLimiter, never()).checkLimit("passwordResetIp", "1.2.3.4");
     verify(joinPoint, never()).proceed();
   }
 }

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/common/ratelimit/RateLimiterTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/common/ratelimit/RateLimiterTest.java
@@ -1,5 +1,6 @@
 package com.acs.bookingsystem.common.ratelimit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -66,6 +67,16 @@ class RateLimiterTest {
     rateLimiter.checkLimit("login", "1.1.1.1");
 
     assertThatCode(() -> rateLimiter.checkLimit("login", "2.2.2.2")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void throwsWhenBucketNameNotConfigured() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> rateLimiter.checkLimit("unknownBucket", "1.2.3.4"));
+
+    assertThat(exception.getMessage()).contains("unknownBucket");
   }
 
   @Test

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/common/ratelimit/RateLimiterTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/common/ratelimit/RateLimiterTest.java
@@ -1,0 +1,101 @@
+package com.acs.bookingsystem.common.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.github.bucket4j.TimeMeter;
+import io.github.bucket4j.caffeine.CaffeineProxyManager;
+import io.github.bucket4j.distributed.proxy.ClientSideConfig;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RateLimiterTest {
+
+  private FakeTimeMeter clock;
+  private RateLimiter rateLimiter;
+
+  @BeforeEach
+  void setUp() {
+    clock = new FakeTimeMeter();
+
+    RateLimitProperties.Bucket bucketConfig = new RateLimitProperties.Bucket();
+    bucketConfig.setCapacity(3);
+    bucketConfig.setRefillPeriod(Duration.ofMinutes(1));
+
+    RateLimitProperties properties = new RateLimitProperties();
+    properties.setBuckets(Map.of("login", bucketConfig));
+
+    ProxyManager<String> proxyManager =
+        new CaffeineProxyManager<>(
+            Caffeine.newBuilder().maximumSize(100),
+            Duration.ofHours(1),
+            ClientSideConfig.getDefault().withClientClock(clock));
+
+    rateLimiter = new RateLimiter(properties, proxyManager);
+  }
+
+  @Test
+  void allowsRequestsUpToCapacity() {
+    assertThatCode(
+            () -> {
+              rateLimiter.checkLimit("login", "1.2.3.4");
+              rateLimiter.checkLimit("login", "1.2.3.4");
+              rateLimiter.checkLimit("login", "1.2.3.4");
+            })
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void blocksRequestBeyondCapacity() {
+    rateLimiter.checkLimit("login", "1.2.3.4");
+    rateLimiter.checkLimit("login", "1.2.3.4");
+    rateLimiter.checkLimit("login", "1.2.3.4");
+
+    assertThrows(
+        RateLimitExceededException.class, () -> rateLimiter.checkLimit("login", "1.2.3.4"));
+  }
+
+  @Test
+  void independentKeysGetIndependentBuckets() {
+    rateLimiter.checkLimit("login", "1.1.1.1");
+    rateLimiter.checkLimit("login", "1.1.1.1");
+    rateLimiter.checkLimit("login", "1.1.1.1");
+
+    assertThatCode(() -> rateLimiter.checkLimit("login", "2.2.2.2")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void refillsTokensAfterTimePasses() {
+    rateLimiter.checkLimit("login", "1.2.3.4");
+    rateLimiter.checkLimit("login", "1.2.3.4");
+    rateLimiter.checkLimit("login", "1.2.3.4");
+    assertThrows(
+        RateLimitExceededException.class, () -> rateLimiter.checkLimit("login", "1.2.3.4"));
+
+    clock.advance(Duration.ofSeconds(20));
+
+    assertThatCode(() -> rateLimiter.checkLimit("login", "1.2.3.4")).doesNotThrowAnyException();
+  }
+
+  private static class FakeTimeMeter implements TimeMeter {
+    private long nanos = 0;
+
+    void advance(Duration duration) {
+      nanos += duration.toNanos();
+    }
+
+    @Override
+    public long currentTimeNanos() {
+      return nanos;
+    }
+
+    @Override
+    public boolean isWallClockBased() {
+      return false;
+    }
+  }
+}

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/user/controller/AuthenticationControllerTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/user/controller/AuthenticationControllerTest.java
@@ -48,7 +48,11 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 @TestPropertySource(
     properties = {
       "rate-limit.buckets.login.capacity=5",
-      "rate-limit.buckets.login.refill-period=10m"
+      "rate-limit.buckets.login.refill-period=10m",
+      "rate-limit.buckets.passwordResetIp.capacity=5",
+      "rate-limit.buckets.passwordResetIp.refill-period=10m",
+      "rate-limit.buckets.checkInvite.capacity=5",
+      "rate-limit.buckets.checkInvite.refill-period=10m"
     })
 class AuthenticationControllerTest {
 
@@ -127,6 +131,34 @@ class AuthenticationControllerTest {
         .perform(get("/api/v1/auth/invitations").param("email", "unknown@example.com"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.invited").value(false));
+  }
+
+  @Test
+  void givenSixthRequestFromSameIp_whenCheckInvite_thenReturns429() throws Exception {
+    when(userService.isEmailInvited("invited@example.com")).thenReturn(true);
+
+    RequestPostProcessor fromDedicatedTestIp =
+        req -> {
+          req.setRemoteAddr("10.10.10.52");
+          return req;
+        };
+
+    for (int i = 0; i < 5; i++) {
+      mockMvc
+          .perform(
+              get("/api/v1/auth/invitations")
+                  .with(fromDedicatedTestIp)
+                  .param("email", "invited@example.com"))
+          .andExpect(status().isOk());
+    }
+
+    mockMvc
+        .perform(
+            get("/api/v1/auth/invitations")
+                .with(fromDedicatedTestIp)
+                .param("email", "invited@example.com"))
+        .andExpect(status().isTooManyRequests())
+        .andExpect(header().exists("Retry-After"));
   }
 
   @Test
@@ -217,6 +249,68 @@ class AuthenticationControllerTest {
     mockMvc
         .perform(
             post("/api/v1/auth/login")
+                .with(fromDedicatedTestIp)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isTooManyRequests())
+        .andExpect(header().exists("Retry-After"));
+  }
+
+  @Test
+  void givenFourResetsForSameEmail_whenResetPassword_thenReturns429() throws Exception {
+    ResetPasswordRequest request = new ResetPasswordRequest("email-limit-test@example.com");
+
+    RequestPostProcessor fromDedicatedTestIp =
+        req -> {
+          req.setRemoteAddr("10.10.10.50");
+          return req;
+        };
+
+    for (int i = 0; i < 3; i++) {
+      mockMvc
+          .perform(
+              post("/api/v1/auth/password-reset")
+                  .with(fromDedicatedTestIp)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isOk());
+    }
+
+    mockMvc
+        .perform(
+            post("/api/v1/auth/password-reset")
+                .with(fromDedicatedTestIp)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isTooManyRequests())
+        .andExpect(header().exists("Retry-After"));
+  }
+
+  @Test
+  void givenSixResetsFromSameIpForDifferentEmails_whenResetPassword_thenReturns429()
+      throws Exception {
+    RequestPostProcessor fromDedicatedTestIp =
+        req -> {
+          req.setRemoteAddr("10.10.10.51");
+          return req;
+        };
+
+    for (int i = 0; i < 5; i++) {
+      ResetPasswordRequest request =
+          new ResetPasswordRequest("ip-limit-test-" + i + "@example.com");
+      mockMvc
+          .perform(
+              post("/api/v1/auth/password-reset")
+                  .with(fromDedicatedTestIp)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isOk());
+    }
+
+    ResetPasswordRequest request = new ResetPasswordRequest("ip-limit-test-5@example.com");
+    mockMvc
+        .perform(
+            post("/api/v1/auth/password-reset")
                 .with(fromDedicatedTestIp)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))

--- a/booking-system-app/src/test/java/com/acs/bookingsystem/user/controller/AuthenticationControllerTest.java
+++ b/booking-system-app/src/test/java/com/acs/bookingsystem/user/controller/AuthenticationControllerTest.java
@@ -4,9 +4,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.acs.bookingsystem.common.ratelimit.ClientIpResolver;
+import com.acs.bookingsystem.common.ratelimit.RateLimitAspect;
+import com.acs.bookingsystem.common.ratelimit.RateLimitProperties;
+import com.acs.bookingsystem.common.ratelimit.RateLimiter;
 import com.acs.bookingsystem.security.config.SecurityConfig;
 import com.acs.bookingsystem.security.util.JwtUtil;
 import com.acs.bookingsystem.user.request.AuthenticateRequest;
@@ -18,18 +23,33 @@ import com.acs.bookingsystem.user.response.RegisterResponse;
 import com.acs.bookingsystem.user.service.AuthenticationService;
 import com.acs.bookingsystem.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.github.bucket4j.caffeine.CaffeineProxyManager;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import java.time.Duration;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 @WebMvcTest(AuthenticationController.class)
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, AuthenticationControllerTest.RateLimitTestConfig.class})
+@TestPropertySource(
+    properties = {
+      "rate-limit.buckets.login.capacity=5",
+      "rate-limit.buckets.login.refill-period=10m"
+    })
 class AuthenticationControllerTest {
 
   @Autowired private MockMvc mockMvc;
@@ -170,5 +190,64 @@ class AuthenticationControllerTest {
                 .content(
                     objectMapper.writeValueAsString(new AuthenticateRequest("a@b.com", "pass"))))
         .andExpect(status().isOk());
+  }
+
+  @Test
+  void givenSixthRequestFromSameIp_whenLogin_thenReturns429() throws Exception {
+    AuthenticateRequest request = new AuthenticateRequest("limited@example.com", "Password1!");
+    when(authenticationService.authenticate(any()))
+        .thenReturn(AuthenticateResponse.builder().token("jwt-token").build());
+
+    RequestPostProcessor fromDedicatedTestIp =
+        req -> {
+          req.setRemoteAddr("10.10.10.99");
+          return req;
+        };
+
+    for (int i = 0; i < 5; i++) {
+      mockMvc
+          .perform(
+              post("/api/v1/auth/login")
+                  .with(fromDedicatedTestIp)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isOk());
+    }
+
+    mockMvc
+        .perform(
+            post("/api/v1/auth/login")
+                .with(fromDedicatedTestIp)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isTooManyRequests())
+        .andExpect(header().exists("Retry-After"));
+  }
+
+  @TestConfiguration
+  @EnableAspectJAutoProxy(proxyTargetClass = true)
+  @EnableConfigurationProperties(RateLimitProperties.class)
+  static class RateLimitTestConfig {
+
+    @Bean
+    ProxyManager<String> rateLimitProxyManager() {
+      return new CaffeineProxyManager<>(
+          Caffeine.newBuilder().maximumSize(100), Duration.ofHours(1));
+    }
+
+    @Bean
+    ClientIpResolver clientIpResolver() {
+      return new ClientIpResolver();
+    }
+
+    @Bean
+    RateLimiter rateLimiter(RateLimitProperties properties, ProxyManager<String> proxyManager) {
+      return new RateLimiter(properties, proxyManager);
+    }
+
+    @Bean
+    RateLimitAspect rateLimitAspect(RateLimiter rateLimiter, ClientIpResolver clientIpResolver) {
+      return new RateLimitAspect(rateLimiter, clientIpResolver);
+    }
   }
 }

--- a/booking-system-it/src/test/java/com/acs/bookingsystem/user/controller/RateLimitIT.java
+++ b/booking-system-it/src/test/java/com/acs/bookingsystem/user/controller/RateLimitIT.java
@@ -1,0 +1,33 @@
+package com.acs.bookingsystem.user.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.acs.bookingsystem.BaseIntegrationTest;
+import com.acs.bookingsystem.user.request.RegisterRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class RateLimitIT extends BaseIntegrationTest {
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  @Test
+  void givenMoreThanTenRegistrationsFromSameIp_whenRegister_thenEventuallyReturns429() {
+    ResponseEntity<String> lastResponse = null;
+
+    for (int i = 0; i < 11; i++) {
+      RegisterRequest request =
+          new RegisterRequest(
+              "Test", "User", "rate-limit-it-" + i + "@example.com", "07123456789", "Password1!");
+      lastResponse = restTemplate.postForEntity("/api/v1/auth/register", request, String.class);
+    }
+
+    assertThat(lastResponse.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+    assertThat(lastResponse.getHeaders().getFirst("Retry-After")).isNotNull();
+  }
+}

--- a/docs/superpowers/specs/2026-07-10-rate-limiting-design.md
+++ b/docs/superpowers/specs/2026-07-10-rate-limiting-design.md
@@ -2,11 +2,13 @@
 
 **Ticket:** BOO-8 — Add rate limiting to auth endpoints
 
-**Goal:** Stop unlimited, zero-cost automated abuse of the unauthenticated auth endpoints — credential brute-forcing on login, password-reset spam, and bot mass account creation on register — while keeping the mechanism generic enough that adding rate limiting to a new endpoint later is a config/annotation change, not new plumbing.
+**Goal:** Stop unlimited, zero-cost automated abuse of the unauthenticated auth endpoints — credential brute-forcing on login, password-reset spam, bot mass account creation on register, and invite-list enumeration — while keeping the mechanism generic enough that adding rate limiting to a new endpoint later is a config/annotation change, not new plumbing.
 
 ## Scope
 
-In scope: `POST /auth/login`, `POST /auth/password-reset`, `POST /auth/register`.
+In scope: `POST /auth/login`, `POST /auth/password-reset`, `POST /auth/register`, `GET /auth/invitations`.
+
+`GET /auth/invitations` (`AuthenticationController#checkInvite`) was added during design review: it's on the same permit-all `/api/*/auth/**` path as the other three, takes an email and returns whether it's invited — letting anyone enumerate the invite list for free by scripting through email addresses. Same profile (unauthenticated, zero-cost, IP-keyable) as the rest of this ticket's scope.
 
 Out of scope (explicitly, not silently dropped):
 - Rate limiting any other endpoint. Every other route in this app already requires a valid JWT (`SecurityConfig` permits only `/api/*/auth/**` and swagger/h2-console; everything else is `authenticated()`). Anonymous, zero-cost abuse — the threat this ticket addresses — is only possible against the three endpoints above. Authenticated-endpoint abuse (e.g. booking-creation scraping) is a different threat model (would key by user ID, not IP, and needs per-endpoint usage data to size limits sensibly) and belongs in its own ticket if it's ever observed.
@@ -14,7 +16,7 @@ Out of scope (explicitly, not silently dropped):
 
 ## Architecture
 
-A custom `@RateLimit` annotation plus a Spring AOP `@Around` aspect (`RateLimitAspect`) wraps the three controller methods. Flow per request:
+A custom `@RateLimit` annotation plus a Spring AOP `@Around` aspect (`RateLimitAspect`) wraps the four controller methods. Flow per request:
 
 1. Spring MVC resolves and validates method arguments as normal (`@Valid` on the request body already ran).
 2. The aspect resolves a **key** for the request — client IP, or a value pulled from the (already-validated) request body via SpEL.
@@ -42,9 +44,10 @@ Bucket4j's `ProxyManager` is built around "get-or-create a bucket for key X," ba
 - `@RateLimit(bucket = "login", key = RateLimitKeyType.IP)` on `AuthenticationController#login`.
 - `@RateLimit(bucket = "passwordReset", key = RateLimitKeyType.SPEL, keyExpression = "#request.email()")` on `resetPassword`.
 - `@RateLimit(bucket = "register", key = RateLimitKeyType.IP)` on `register`.
+- `@RateLimit(bucket = "checkInvite", key = RateLimitKeyType.IP)` on `checkInvite`.
 - `RateLimitAspect` — the `@Around` advice described above.
 - `ClientIpResolver` — resolves the key for IP-based buckets.
-- `RateLimitProperties` (`@ConfigurationProperties(prefix = "rate-limit")`) — nested static `Login` / `PasswordReset` / `Register` classes (`capacity`, `refillPeriod`, `refillStrategy`), following the existing `EmailProperties` / `ScheduleProperties` convention in this repo.
+- `RateLimitProperties` (`@ConfigurationProperties(prefix = "rate-limit")`) — nested static `Login` / `PasswordReset` / `Register` / `CheckInvite` classes (`capacity`, `refillPeriod`, `refillStrategy`), following the existing `EmailProperties` / `ScheduleProperties` convention in this repo.
 - `RateLimitExceededException` — new exception, mapped in `UniversalExceptionHandler` to `429`, using the existing `ErrorModel` shape, plus a `Retry-After` header computed from Bucket4j's `ConsumptionProbe.getNanosToWaitForRefill()`.
 
 ## Endpoints and default limits
@@ -56,8 +59,10 @@ All limits below are defaults, fully configurable via `rate-limit.*` properties 
 | `POST /auth/login` | Client IP | 10 | 10 tokens / 1 minute | Greedy |
 | `POST /auth/password-reset` | Email (request body) | 3 | 3 tokens / 15 minutes | Greedy |
 | `POST /auth/register` | Client IP | 10 | 10 tokens / 1 hour | Greedy |
+| `GET /auth/invitations` | Client IP | 20 | 20 tokens / 1 minute | Greedy |
 
 Notes:
+- **Invitations: 20/minute/IP.** This is a read-only lookup (no email sent, no account created), so the cost of a legitimate burst is low — the limit here exists purely to stop email-list enumeration/scraping at scale, not to protect a scarce resource. Generous enough not to interfere with a real registration flow's own invite check.
 - **Login: 10/minute, not the ticket's literal 5/minute.** Discussed explicitly during design: the security difference between 5 and 10 attempts/minute against a real password's keyspace is negligible (both make online brute-forcing impractical), while 10 meaningfully reduces false-positive lockouts from typos/autofill/caps-lock. Keyed by IP (not account), which also avoids the OWASP-flagged risk of account-based lockout being usable as a DoS against a legitimate user.
 - **Greedy refill is the default for all three buckets**, not intervally (fixed-window) refill. Greedy replenishes tokens continuously (e.g. login's 10/min ≈ 1 token every 6s) rather than resetting the whole bucket at a clock boundary, avoiding the classic fixed-window flaw where a client could burst, wait a fraction of a second past the boundary, and immediately burst again for up to 2x the intended limit.
 - **Register's limit (10/hour/IP) is not specified by the ticket** — it was added during design discussion since `/auth/register` shares the same unauthenticated, zero-cost profile as login/password-reset. Starting default is generous enough to not block legitimate shared-IP signups (e.g. an office) while still blocking bot mass-registration; expected to be tuned from real usage/abuse data post-launch.

--- a/docs/superpowers/specs/2026-07-10-rate-limiting-design.md
+++ b/docs/superpowers/specs/2026-07-10-rate-limiting-design.md
@@ -1,0 +1,79 @@
+# Rate Limiting for Auth Endpoints — Design
+
+**Ticket:** BOO-8 — Add rate limiting to auth endpoints
+
+**Goal:** Stop unlimited, zero-cost automated abuse of the unauthenticated auth endpoints — credential brute-forcing on login, password-reset spam, and bot mass account creation on register — while keeping the mechanism generic enough that adding rate limiting to a new endpoint later is a config/annotation change, not new plumbing.
+
+## Scope
+
+In scope: `POST /auth/login`, `POST /auth/password-reset`, `POST /auth/register`.
+
+Out of scope (explicitly, not silently dropped):
+- Rate limiting any other endpoint. Every other route in this app already requires a valid JWT (`SecurityConfig` permits only `/api/*/auth/**` and swagger/h2-console; everything else is `authenticated()`). Anonymous, zero-cost abuse — the threat this ticket addresses — is only possible against the three endpoints above. Authenticated-endpoint abuse (e.g. booking-creation scraping) is a different threat model (would key by user ID, not IP, and needs per-endpoint usage data to size limits sensibly) and belongs in its own ticket if it's ever observed.
+- Email verification at registration (proving the registrant owns the email address) and login 2FA. Both are legitimate, separate hardening ideas raised during design discussion, but are distinct mechanisms (new account states, token/link flows, OTP delivery) that deserve their own design — not part of this ticket.
+
+## Architecture
+
+A custom `@RateLimit` annotation plus a Spring AOP `@Around` aspect (`RateLimitAspect`) wraps the three controller methods. Flow per request:
+
+1. Spring MVC resolves and validates method arguments as normal (`@Valid` on the request body already ran).
+2. The aspect resolves a **key** for the request — client IP, or a value pulled from the (already-validated) request body via SpEL.
+3. It asks Bucket4j for the bucket at `{bucket-name}:{key}`, backed by a Caffeine cache (`ProxyManager`), creating the bucket on first use with limits from `RateLimitProperties`.
+4. It attempts to consume one token. If available, the controller method proceeds. If not, it throws `RateLimitExceededException`.
+
+Because this is AOP around the controller method (not a raw servlet `Filter`), the exception flows through Spring MVC's normal exception-resolution path and is handled by the existing `UniversalExceptionHandler`, like every other error in this app — no bespoke response-writing in a filter.
+
+`JwtAuthenticationFilter` needs no changes: it already runs harmlessly ahead of these requests (no token present, route is permit-all), one layer outside where the aspect operates.
+
+## Why Bucket4j (not Resilience4j, not hand-rolled)
+
+Bucket4j's `ProxyManager` is built around "get-or-create a bucket for key X," backed by a cache with automatic eviction — a direct match for "one independent limiter per IP/email," of which there will be many, created dynamically. Resilience4j's `RateLimiter` is designed to guard a single shared resource (one named limiter, configured once); using it here would mean hand-rolling a `ConcurrentHashMap<String, RateLimiter>` and managing eviction ourselves — reintroducing the memory-leak risk a keyed limiter is supposed to avoid. A hand-rolled Caffeine counter was also considered and rejected: it would reimplement token-bucket refill logic Bucket4j already provides correctly, with a real edge case (fixed-window boundary bursts) that Bucket4j's greedy refill avoids.
+
+**Storage backend:** Caffeine (in-memory), not Redis. Nothing in this repo's deployment (single `Dockerfile`, no LB/ingress, no Redis in `docker-compose`) indicates multi-instance deployment today. Bucket4j's `ProxyManager` abstraction means swapping Caffeine for Redis later (if the app ever scales to multiple instances) doesn't require touching the annotation/aspect code — only the `ProxyManager` bean wiring.
+
+## Client IP resolution
+
+`ClientIpResolver` (single bean, `request.getRemoteAddr()`) — deliberately **not** trusting `X-Forwarded-For` or enabling `server.forwarded-headers-strategy: framework`. Confirmed via repo inspection: there is no reverse proxy, load balancer, or CDN in front of this app today. Spring's forwarded-header support does not validate that a header came from a trusted hop — it trusts whatever is present. Enabling it without a trusted proxy in front would let a client set an arbitrary `X-Forwarded-For` value per request and defeat the rate limiter entirely, which is worse than doing nothing.
+
+**Assumption / risk to revisit:** if this app is ever deployed behind a real reverse proxy or load balancer, `getRemoteAddr()` will return the proxy's IP for every request, collapsing all clients into one shared bucket. At that point, switch `ClientIpResolver` to trust forwarded headers — but only once it's confirmed the proxy strips/overwrites any client-supplied `X-Forwarded-For` before forwarding. `ClientIpResolver` is a single, isolated bean specifically so this is a one-place change when that day comes.
+
+## Components
+
+- `@RateLimit(bucket = "login", key = RateLimitKeyType.IP)` on `AuthenticationController#login`.
+- `@RateLimit(bucket = "passwordReset", key = RateLimitKeyType.SPEL, keyExpression = "#request.email()")` on `resetPassword`.
+- `@RateLimit(bucket = "register", key = RateLimitKeyType.IP)` on `register`.
+- `RateLimitAspect` — the `@Around` advice described above.
+- `ClientIpResolver` — resolves the key for IP-based buckets.
+- `RateLimitProperties` (`@ConfigurationProperties(prefix = "rate-limit")`) — nested static `Login` / `PasswordReset` / `Register` classes (`capacity`, `refillPeriod`, `refillStrategy`), following the existing `EmailProperties` / `ScheduleProperties` convention in this repo.
+- `RateLimitExceededException` — new exception, mapped in `UniversalExceptionHandler` to `429`, using the existing `ErrorModel` shape, plus a `Retry-After` header computed from Bucket4j's `ConsumptionProbe.getNanosToWaitForRefill()`.
+
+## Endpoints and default limits
+
+All limits below are defaults, fully configurable via `rate-limit.*` properties — not hardcoded, per the ticket's acceptance criteria.
+
+| Endpoint | Key | Capacity | Refill | Strategy |
+|---|---|---|---|---|
+| `POST /auth/login` | Client IP | 10 | 10 tokens / 1 minute | Greedy |
+| `POST /auth/password-reset` | Email (request body) | 3 | 3 tokens / 15 minutes | Greedy |
+| `POST /auth/register` | Client IP | 10 | 10 tokens / 1 hour | Greedy |
+
+Notes:
+- **Login: 10/minute, not the ticket's literal 5/minute.** Discussed explicitly during design: the security difference between 5 and 10 attempts/minute against a real password's keyspace is negligible (both make online brute-forcing impractical), while 10 meaningfully reduces false-positive lockouts from typos/autofill/caps-lock. Keyed by IP (not account), which also avoids the OWASP-flagged risk of account-based lockout being usable as a DoS against a legitimate user.
+- **Greedy refill is the default for all three buckets**, not intervally (fixed-window) refill. Greedy replenishes tokens continuously (e.g. login's 10/min ≈ 1 token every 6s) rather than resetting the whole bucket at a clock boundary, avoiding the classic fixed-window flaw where a client could burst, wait a fraction of a second past the boundary, and immediately burst again for up to 2x the intended limit.
+- **Register's limit (10/hour/IP) is not specified by the ticket** — it was added during design discussion since `/auth/register` shares the same unauthenticated, zero-cost profile as login/password-reset. Starting default is generous enough to not block legitimate shared-IP signups (e.g. an office) while still blocking bot mass-registration; expected to be tuned from real usage/abuse data post-launch.
+
+## Error handling
+
+`RateLimitExceededException` → `@ExceptionHandler` in `UniversalExceptionHandler` → HTTP `429`, body via the existing `ErrorModel(timestamp, status, error, message, details)` record, plus a `Retry-After` header (seconds until next token, from `ConsumptionProbe`).
+
+## Testing
+
+- **Unit (`RateLimitAspectTest`):** request N+1 within the window is blocked; independent keys (different IPs/emails) get independent buckets; bucket refills correctly after time passes — using a controllable/fake clock, not real sleeps.
+- **Controller (`AuthenticationControllerTest`, `@WebMvcTest`):** extend with cases like `givenLimitExceeded_whenLogin_thenReturns429`, following the existing given/when/then naming convention in this file.
+- **Integration (`booking-system-it` module):** new IT hitting real HTTP endpoints repeatedly to confirm end-to-end 429 behavior including the `Retry-After` header — new addition to this module, since there's no existing auth IT to extend (current ITs are repository-layer only).
+
+## Open assumptions to revisit later
+
+- No reverse proxy/LB in front of the app today — `ClientIpResolver` will need updating if that changes (see Client IP resolution section).
+- Register's rate limit numbers are a starting guess, not derived from real traffic/abuse data — expect to tune post-launch.
+- Email verification at registration and login 2FA are known, separate gaps raised during design; intentionally out of scope here (see Scope section).

--- a/docs/superpowers/specs/2026-07-10-rate-limiting-design.md
+++ b/docs/superpowers/specs/2026-07-10-rate-limiting-design.md
@@ -42,13 +42,18 @@ Bucket4j's `ProxyManager` is built around "get-or-create a bucket for key X," ba
 ## Components
 
 - `@RateLimit(bucket = "login", key = RateLimitKeyType.IP)` on `AuthenticationController#login`.
-- `@RateLimit(bucket = "passwordReset", key = RateLimitKeyType.SPEL, keyExpression = "#request.email()")` on `resetPassword`.
+- `@RateLimit(bucket = "passwordReset", key = RateLimitKeyType.SPEL, keyExpression = "#request.email()")` plus a stacked `@RateLimit(bucket = "passwordResetIp", key = RateLimitKeyType.IP)` on `resetPassword` — see "Stacked rate limits" below.
 - `@RateLimit(bucket = "register", key = RateLimitKeyType.IP)` on `register`.
 - `@RateLimit(bucket = "checkInvite", key = RateLimitKeyType.IP)` on `checkInvite`.
+- `@RateLimit` is `@Repeatable(RateLimits.class)`, so a method can carry more than one independent limit; `RateLimitAspect` matches on either the single annotation or the synthesized `@RateLimits` container and checks every `@RateLimit` present via `Method#getAnnotationsByType`, in declaration order, stopping at the first breach.
 - `RateLimitAspect` — the `@Around` advice described above.
 - `ClientIpResolver` — resolves the key for IP-based buckets.
-- `RateLimitProperties` (`@ConfigurationProperties(prefix = "rate-limit")`) — nested static `Login` / `PasswordReset` / `Register` / `CheckInvite` classes (`capacity`, `refillPeriod`, `refillStrategy`), following the existing `EmailProperties` / `ScheduleProperties` convention in this repo.
+- `RateLimitProperties` (`@ConfigurationProperties(prefix = "rate-limit")`) — a single `Map<String, Bucket>` keyed by bucket name (`login`, `passwordReset`, `passwordResetIp`, `register`, `checkInvite`), where `Bucket` has `capacity` (long) and `refillPeriod` (Duration). Refill strategy is not a config field — greedy refill is hardcoded in `RateLimiter.buildConfiguration` (see "Endpoints and default limits" below for why). Map keys are matched character-for-character against `@RateLimit(bucket = "...")` values and the `rate-limit.buckets.*` YAML keys (Spring's relaxed binding does not apply to `Map` keys).
 - `RateLimitExceededException` — new exception, mapped in `UniversalExceptionHandler` to `429`, using the existing `ErrorModel` shape, plus a `Retry-After` header computed from Bucket4j's `ConsumptionProbe.getNanosToWaitForRefill()`.
+
+## Stacked rate limits on password-reset
+
+Password-reset is keyed by email (not IP) to stop flooding a *single* victim's inbox — but an email-only key means nothing stops one attacker IP from iterating a list of N valid emails and triggering up to `passwordReset.capacity` × N reset emails, unthrottled. Found during final review (not the original design pass). Fixed by stacking a second, IP-keyed bucket (`passwordResetIp`) on the same endpoint alongside the existing email-keyed one, reusing the same `@RateLimit` mechanism rather than inventing a special case — this is why `@RateLimit` became `@Repeatable`. Both buckets must have a token available for the request to proceed; the email-keyed check runs first (declared first), so a request from a well-behaved IP hammering one victim's email still gets stopped by the tighter (capacity 3) email bucket before the looser (capacity 10) IP bucket would even matter.
 
 ## Endpoints and default limits
 
@@ -58,14 +63,16 @@ All limits below are defaults, fully configurable via `rate-limit.*` properties 
 |---|---|---|---|---|
 | `POST /auth/login` | Client IP | 10 | 10 tokens / 1 minute | Greedy |
 | `POST /auth/password-reset` | Email (request body) | 3 | 3 tokens / 15 minutes | Greedy |
+| `POST /auth/password-reset` | Client IP (stacked, see above) | 10 | 10 tokens / 1 hour | Greedy |
 | `POST /auth/register` | Client IP | 10 | 10 tokens / 1 hour | Greedy |
 | `GET /auth/invitations` | Client IP | 20 | 20 tokens / 1 minute | Greedy |
 
 Notes:
 - **Invitations: 20/minute/IP.** This is a read-only lookup (no email sent, no account created), so the cost of a legitimate burst is low — the limit here exists purely to stop email-list enumeration/scraping at scale, not to protect a scarce resource. Generous enough not to interfere with a real registration flow's own invite check.
 - **Login: 10/minute, not the ticket's literal 5/minute.** Discussed explicitly during design: the security difference between 5 and 10 attempts/minute against a real password's keyspace is negligible (both make online brute-forcing impractical), while 10 meaningfully reduces false-positive lockouts from typos/autofill/caps-lock. Keyed by IP (not account), which also avoids the OWASP-flagged risk of account-based lockout being usable as a DoS against a legitimate user.
-- **Greedy refill is the default for all three buckets**, not intervally (fixed-window) refill. Greedy replenishes tokens continuously (e.g. login's 10/min ≈ 1 token every 6s) rather than resetting the whole bucket at a clock boundary, avoiding the classic fixed-window flaw where a client could burst, wait a fraction of a second past the boundary, and immediately burst again for up to 2x the intended limit.
+- **Greedy refill is the default for every bucket**, not intervally (fixed-window) refill — hardcoded in `RateLimiter`, not a per-bucket config choice. Greedy replenishes tokens continuously (e.g. login's 10/min ≈ 1 token every 6s) rather than resetting the whole bucket at a clock boundary, avoiding the classic fixed-window flaw where a client could burst, wait a fraction of a second past the boundary, and immediately burst again for up to 2x the intended limit.
 - **Register's limit (10/hour/IP) is not specified by the ticket** — it was added during design discussion since `/auth/register` shares the same unauthenticated, zero-cost profile as login/password-reset. Starting default is generous enough to not block legitimate shared-IP signups (e.g. an office) while still blocking bot mass-registration; expected to be tuned from real usage/abuse data post-launch.
+- **`passwordResetIp` (10/hour/IP) mirrors register's reasoning** — same "bound bulk automation, stay generous for shared IPs" tradeoff, same numbers, added during final review (see "Stacked rate limits" above). Also a starting guess, not derived from real traffic.
 
 ## Error handling
 
@@ -73,9 +80,9 @@ Notes:
 
 ## Testing
 
-- **Unit (`RateLimitAspectTest`):** request N+1 within the window is blocked; independent keys (different IPs/emails) get independent buckets; bucket refills correctly after time passes — using a controllable/fake clock, not real sleeps.
-- **Controller (`AuthenticationControllerTest`, `@WebMvcTest`):** extend with cases like `givenLimitExceeded_whenLogin_thenReturns429`, following the existing given/when/then naming convention in this file.
-- **Integration (`booking-system-it` module):** new IT hitting real HTTP endpoints repeatedly to confirm end-to-end 429 behavior including the `Retry-After` header — new addition to this module, since there's no existing auth IT to extend (current ITs are repository-layer only).
+- **Unit (`RateLimitAspectTest`):** request N+1 within the window is blocked; independent keys (different IPs/emails) get independent buckets; bucket refills correctly after time passes — using a controllable/fake clock, not real sleeps. Also covers the stacked-annotation case directly: both bucket checks run when both are within limit, and a breach on the first-declared bucket stops before checking the second.
+- **Controller (`AuthenticationControllerTest`, `@WebMvcTest`):** one dedicated-IP 429 test per bucket — login, checkInvite, and both of password-reset's stacked buckets (email-keyed and IP-keyed) — each using a unique remote address so buckets don't cross-contaminate across test methods sharing the same Spring context. Register has no dedicated controller-level 429 test (covered end-to-end by the integration test instead). This is also where the stacked-annotation pointcut match gets its real proof: unlike the unit test (which calls the aspect method directly, bypassing AspectJ pointcut matching entirely), these tests go through a real `@EnableAspectJAutoProxy` proxy, so a passing stacked-bucket test here confirms the pointcut genuinely matches methods carrying two `@RateLimit` annotations, not just that the aspect's internal loop logic is correct in isolation.
+- **Integration (`booking-system-it` module):** `RateLimitIT` hits `/auth/register` repeatedly over real HTTP to confirm end-to-end 429 behavior including the `Retry-After` header — new addition to this module, since there's no existing auth IT to extend (other ITs are repository-layer only).
 
 ## Open assumptions to revisit later
 


### PR DESCRIPTION
## Summary
- Adds a generic, reusable rate-limiting mechanism (`@RateLimit` annotation + Spring AOP aspect, Bucket4j token buckets backed by an in-memory Caffeine cache) and applies it to the four unauthenticated auth endpoints: `POST /auth/login`, `POST /auth/register`, `POST /auth/password-reset`, `GET /auth/invitations`.
- Stops credential brute-forcing, bot mass-registration, invite-list enumeration, and password-reset spam. Password-reset carries two stacked limits (email-keyed + IP-keyed) so a single attacker IP can't mass-trigger resets across many victims.
- All limits are configurable via `rate-limit.buckets.*` properties, not hardcoded. Design rationale (why Bucket4j over Resilience4j, why Caffeine over Redis, why `getRemoteAddr()` over trusting `X-Forwarded-For`) is documented in `docs/superpowers/specs/2026-07-10-rate-limiting-design.md`.
- Also includes two smaller, previously-completed pieces of work already sitting on this branch ahead of `master`: BOO-7 (enable Flyway migrations in base config) and a HikariCP datasource tuning commit.

## Test plan
- [x] Unit tests: `RateLimiter` (token bucket/refill/isolation with a fake clock), `RateLimitAspect` (IP + SpEL key resolution, stacked-annotation handling, fail-fast on first breach)
- [x] Controller tests (`@WebMvcTest`, real AOP proxy): dedicated 429 test per bucket — login, checkInvite, and both of password-reset's stacked buckets
- [x] Integration test (`booking-system-it`): real end-to-end HTTP request against `/auth/register`, confirms 429 + `Retry-After` header
- [x] Full `booking-system-app` module suite green
- [x] Full `booking-system-it` module suite green (Testcontainers Postgres, failsafe)
- [x] Independent multi-agent code review at both the per-task and whole-branch level; one whole-branch review finding (password-reset sender unthrottled) fixed and re-verified before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)